### PR TITLE
clean: don't depend on setup.cfg

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -89,6 +89,7 @@ repos_task:
       - REPO: https://github.com/ppb/ppb-vector.git
       - REPO: https://github.com/duckinator/emanate.git
       - REPO: https://github.com/duckinator/bork.git
+      - REPO: https://github.com/astronouth7303/ppb-mutant.git
   install_script:
     - apt-get update
     - apt-get install -y git

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from . import builder
 # from . import github
 from . import pypi
@@ -23,12 +25,11 @@ def build():
 
 
 def clean():
-    config = load_setup_cfg()
-    name = config['metadata']['name']
-
     try_delete("./build")
     try_delete("./dist")
-    try_delete("./{}.egg-info".format(name))
+    for name in Path.cwd().glob('*.egg-info'):
+        if name.is_dir():
+            try_delete(name)
 
 
 def release(dry_run=False):


### PR DESCRIPTION
Don't require pulling the name out of `setup.cfg` for `bork clean`.