### PR TITLE
Linting improvements

### DIFF
--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 import sys
+
 import toml
 
 from . import builder

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 import sys
 # Slight kludge so we can have a function named zipapp().
-import zipapp as Zipapp
+import zipapp as Zipapp  # noqa: N812
 
 import pep517.build
 

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -7,7 +7,7 @@ from . import clean as _clean
 from . import download as _download
 from . import release as _release
 from . import run as _run
-from . import DOWNLOAD_SOURCES
+from . import DOWNLOAD_SOURCES  # noqa: I100
 
 
 DOWNLOAD_SOURCES_STR = ' '.join(DOWNLOAD_SOURCES)

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -28,10 +28,6 @@ def clean():
     _clean()
 
 
-# pylint: disable=redefined-outer-name
-# NOTE: It's okay to redefine `release` in download(), since it doesn't
-#       use release().
-
 @cli.command()
 @click.option('--files', default='*.pyz',
               help='Comma-separated list of filenames to download. Supports '
@@ -39,12 +35,12 @@ def clean():
 @click.option('--directory', default='downloads',
               help='Directory to save files in. Created if missing.')
 @click.argument('package', nargs=1)
-@click.argument('release', nargs=1, default='latest')
-def download(files, directory, package, release):
+@click.argument('release_tag', nargs=1, default='latest')
+def download(files, directory, package, release_tag):
     # NOTE: We change the order of the arguments here, to move away from
     #       what makes sense on a CLI interface to what makes sense in a
     #       Python interface.
-    _download(package, release, files, directory)
+    _download(package, release_tag, files, directory)
 
 # pylint: enable=redefined-outer-name
 

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -1,4 +1,5 @@
 from twine.cli import dispatch as twine_upload
+
 from .asset_manager import download_assets
 from .filesystem import find_files
 from .pypi_api import get_download_info

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ linting =
     flake8-commas==2.0.0
     flake8-docstrings==1.4.0
     flake8-import-order
+    pep8-naming
     # pydocstyle is pinned due to https://gitlab.com/pycqa/flake8-docstrings/issues/36
     pydocstyle==4.0.1
     pylint==2.4.1
@@ -51,7 +52,7 @@ console_scripts =
     bork = bork.cli:main
 
 [flake8]
-select = C,E,F,I,W,B,B9
+select = C,E,F,I,N,W,B,B9
 max-line-length = 85
 exclude =
     .eggs,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ linting =
     flake8-bugbear==19.8.0
     flake8-commas==2.0.0
     flake8-docstrings==1.4.0
+    flake8-import-order
     # pydocstyle is pinned due to https://gitlab.com/pycqa/flake8-docstrings/issues/36
     pydocstyle==4.0.1
     pylint==2.4.1
@@ -50,7 +51,7 @@ console_scripts =
     bork = bork.cli:main
 
 [flake8]
-select = C,E,F,W,B,B9
+select = C,E,F,I,W,B,B9
 max-line-length = 85
 exclude =
     .eggs,
@@ -60,3 +61,5 @@ exclude =
     build,
     dist,
     venv
+
+import-order-style = google

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,11 +35,9 @@ linting =
     flake8==3.7.8
     flake8-bugbear==19.8.0
     flake8-commas==2.0.0
-    flake8-docstrings==1.4.0
+    flake8-docstrings==1.5.0
     flake8-import-order
     pep8-naming
-    # pydocstyle is pinned due to https://gitlab.com/pycqa/flake8-docstrings/issues/36
-    pydocstyle==4.0.1
     pylint==2.4.1
 
 testing =


### PR DESCRIPTION
1. Uniformise imports order, enforce it in linting.
2. Fix minor wart in `bork.cli.download`.
3. Enforce PEP8 naming conventions.
4. Pin the newest version of `flake8-docstrings`.

@duckinator (3) seems kinda iffy to me, feel free to drop the corresponding commit prior to merge.
