### PR TITLE
Improve bork.run

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -36,3 +36,7 @@ disable=missing-docstring,
 # and msvs (visual studio).You can also give a reporter class, eg
 # mypackage.mymodule.MyReporterClass.
 output-format=colorized
+
+[TYPECHECK]
+# Workaround for https://github.com/PyCQA/pylint/issues/2804
+ignored-modules=signal

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from signal import Signals
 import subprocess
-from subprocess import CalledProcessError, PIPE
 import sys
 import toml
 
@@ -78,8 +77,7 @@ def run(alias):
         sys.exit("bork: no such alias: '{}'".format(alias))
 
     try:
-        subprocess.run(command, check=True, shell=True,
-                       stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        subprocess.run(command, check=True, shell=True)
 
     except subprocess.CalledProcessError as error:
         if error.returncode < 0:

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -69,11 +69,10 @@ def release(test_pypi, dry_run):
 
 def run(alias):
     pyproject = toml.load('pyproject.toml')
-    config = pyproject.get('tool', {}).get('bork', {})
-    aliases = config.get('aliases', {})
 
-    if alias not in aliases.keys():
+    try:
+        command = pyproject['tool']['bork']['aliases'][alias]
+    except KeyError:
         sys.exit("bork: no such alias: '{}'".format(alias))
 
-    command = aliases[alias]
     os.system(command)

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -1,5 +1,6 @@
-import os
 from pathlib import Path
+import subprocess
+from subprocess import PIPE
 import sys
 import toml
 
@@ -75,4 +76,4 @@ def run(alias):
     except KeyError:
         sys.exit("bork: no such alias: '{}'".format(alias))
 
-    os.system(command)
+    subprocess.run(command, shell=True, stdin=PIPE, stdout=PIPE, stderr=PIPE)

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -73,7 +73,7 @@ def run(alias):
     aliases = config.get('aliases', {})
 
     if alias not in aliases.keys():
-        sys.exit('bork: no such alias: {}'.format(alias))
+        sys.exit("bork: no such alias: '{}'".format(alias))
 
     command = aliases[alias]
     os.system(command)


### PR DESCRIPTION
- [x] Simplify the code that fetches `command` from the config.
- [x] Replace deprecated `os.system` with `subprocess.run`.
- [x] Do not silently hide non-zero exits from commands.
- [x] Provide better error messages when a command fails.