### PR TITLE
Cirrus: Add missing dependencies on pytest* in Lint task

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -7,7 +7,7 @@ Lint_task:
     image: python:3.7-slim
   install_script:
     - pip install .
-    - pip install .[linting]
+    - pip install .[testing]
   script:
     - flake8 --version
     - pylint --version


### PR DESCRIPTION
CI calls `bork run lint`, which in turn calls `pytest`, so we need `pytest` installed, along with its integrations for `flake8` and `pylint`.