### PR TITLE
bork.cli: Remove superfluous pylint annotation

### DIFF
--- a/bork/cli.py
+++ b/bork/cli.py
@@ -42,8 +42,6 @@ def download(files, directory, package, release_tag):
     #       Python interface.
     _download(package, release_tag, files, directory)
 
-# pylint: enable=redefined-outer-name
-
 
 @cli.command()
 @click.option('--test-pypi', is_flag=True, default=False,


### PR DESCRIPTION
The matching `disable` annotation was removed in PR #39 (f93c3c6)