### PR TITLE
Bors: Delete merged branches from the main repo

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -5,3 +5,5 @@ status = [
   "repos REPO:https://github.com/ppb/ppb-vector.git",
   "repos REPO:https://github.com/astronouth7303/ppb-mutant.git",
 ]
+
+delete_merged_branches = true


### PR DESCRIPTION
This avoids having old feature branches lying around, esp. from @pyup-bot.