### PR TITLE
Add structured logging

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,8 @@ disable=missing-docstring,
         bad-whitespace,
         bad-continuation,
         len-as-condition,
-        compare-to-zero
+        compare-to-zero,
+        invalid-name  # flake8 already enforces PEP8 naming
 
 
 [REPORTS]

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -9,6 +9,7 @@ from . import builder
 from . import github
 from . import pypi
 from .filesystem import try_delete
+from .log import logger
 
 
 DOWNLOAD_SOURCES = {
@@ -62,9 +63,6 @@ def release(test_pypi, dry_run):
         pypi_instance = pypi.PRODUCTION
     pypi_instance.upload('./dist/*.tar.gz', './dist/*.whl', dry_run=dry_run)
 
-    print('')
-    print('')
-
     # if 'github' in args:
     #     github.upload('./dist/*.pyz', dry_run=dry_run)
 
@@ -76,6 +74,8 @@ def run(alias):
         command = pyproject['tool']['bork']['aliases'][alias]
     except KeyError:
         sys.exit("bork: no such alias: '{}'".format(alias))
+
+    logger().info("Running '%s'", command)
 
     try:
         subprocess.run(command, check=True, shell=True)

--- a/bork/__init__.py
+++ b/bork/__init__.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from signal import Signals
 import subprocess
-import sys
 
 import toml
 
@@ -73,7 +72,7 @@ def run(alias):
     try:
         command = pyproject['tool']['bork']['aliases'][alias]
     except KeyError:
-        sys.exit("bork: no such alias: '{}'".format(alias))
+        raise RuntimeError("No such alias: '{}'".format(alias))
 
     logger().info("Running '%s'", command)
 
@@ -83,9 +82,13 @@ def run(alias):
     except subprocess.CalledProcessError as error:
         if error.returncode < 0:
             signal = Signals(- error.returncode)
-            sys.exit("bork: command '{}' exited due to signal {} ({})".format(
-                error.cmd, signal.name, signal.value))
+            msg = "command '{}' exited due to signal {} ({})".format(
+                error.cmd, signal.name, signal.value,
+            )
 
         else:
-            sys.exit("bork: command '{}' exited with error code {}".format(
-                error.cmd, error.returncode))
+            msg = "bork: command '{}' exited with error code {}".format(
+                error.cmd, error.returncode,
+            )
+
+        raise RuntimeError(msg) from error

--- a/bork/asset_manager.py
+++ b/bork/asset_manager.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from urllib.request import urlopen
 
+from .log import logger
+
 
 def download_assets(asset_list, directory, name_key=None, url_key=None):
     if name_key is None:
@@ -12,6 +14,7 @@ def download_assets(asset_list, directory, name_key=None, url_key=None):
     directory = Path(directory)
     directory.mkdir(parents=True, exist_ok=True)
 
+    log = logger()
     for asset in asset_list:
         name = asset[name_key]
         url = asset[url_key]
@@ -20,4 +23,4 @@ def download_assets(asset_list, directory, name_key=None, url_key=None):
         contents = urlopen(url).read()
 
         path.write_bytes(contents)
-        print(str(path))
+        log.info("Downloaded '%s'", path)

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -8,7 +8,6 @@ import zipapp as Zipapp  # noqa: N812
 import pep517.build
 
 from .filesystem import load_setup_cfg, try_delete
-from .log import logger
 
 
 # The "proper" way to handle the default would be to check python_requires

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -65,10 +65,9 @@ def zipapp():
     config = load_setup_cfg()
 
     if 'metadata' not in config or 'name' not in config['metadata']:
-        logger().error(
+        raise RuntimeError(
             "The [metadata] section of setup.cfg needs the 'name' key set.",
         )
-        raise RuntimeError("Invalid project configuration")
 
     name = config['metadata']['name']
 

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -8,6 +8,7 @@ import zipapp as Zipapp  # noqa: N812
 import pep517.build
 
 from .filesystem import load_setup_cfg, try_delete
+from .log import logger
 
 
 # The "proper" way to handle the default would be to check python_requires
@@ -64,9 +65,10 @@ def zipapp():
     config = load_setup_cfg()
 
     if 'metadata' not in config or 'name' not in config['metadata']:
-        print("The [metadata] section of setup.cfg needs the 'name' key set.",
-              file=sys.stderr)
-        sys.exit(1)
+        logger().error(
+            "The [metadata] section of setup.cfg needs the 'name' key set.",
+        )
+        raise RuntimeError("Invalid project configuration")
 
     name = config['metadata']['name']
 

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -78,9 +78,6 @@ def main():
         thrown = inspect.trace()[-1][3]
         logger = logging.getLogger('bork.{}'.format(thrown))
 
-        if verbose:
-            logger.exception(str(err))
-        else:
-            logger.error(str(err))
+        (logger.exception if verbose else logger.error)(str(err))
 
         sys.exit(1)

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 import click
@@ -67,6 +68,7 @@ def main():
     if verbose:
         sys.argv.remove('--verbose')
 
+    logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
     try:
         cli()
     except RuntimeError as err:

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -11,6 +11,7 @@ from . import download as _download
 from . import release as _release
 from . import run as _run
 from . import DOWNLOAD_SOURCES  # noqa: I100
+from .log import logger
 
 
 DOWNLOAD_SOURCES_STR = ' '.join(DOWNLOAD_SOURCES)
@@ -75,9 +76,9 @@ def main():
         cli()
 
     except RuntimeError as err:
-        thrown = inspect.trace()[-1][3]
-        logger = logging.getLogger('bork.{}'.format(thrown))
+        thrower = inspect.trace()[-1]
+        log = logger(thrower)
 
-        (logger.exception if verbose else logger.error)(str(err))
+        (log.exception if verbose else log.error)(str(err))
 
         sys.exit(1)

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import sys
 
@@ -69,9 +70,17 @@ def main():
         sys.argv.remove('--verbose')
 
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING)
+
     try:
         cli()
+
     except RuntimeError as err:
+        thrown = inspect.trace()[-1][3]
+        logger = logging.getLogger('bork.{}'.format(thrown))
+
         if verbose:
-            raise err
-        sys.exit("bork: error: {}".format(str(err)))
+            logger.exception(str(err))
+        else:
+            logger.error(str(err))
+
+        sys.exit(1)

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -11,16 +11,13 @@ def load_setup_cfg():
     return setup_cfg
 
 
-def find_files(globs, service):
+def find_files(globs):
     files = []
-    log = logger()
 
     for glob in globs:
         matches = map(str, Path().glob(glob))
         files += list(matches)
 
-    # NOTE: This is the wrong place for this log call
-    log.info('Uploading to %s: %s', service, ', '.join(files))
     return files
 
 

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -2,8 +2,6 @@ import configparser
 from pathlib import Path
 import shutil
 
-from .log import logger
-
 
 def load_setup_cfg():
     setup_cfg = configparser.ConfigParser()

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -2,6 +2,8 @@ import configparser
 from pathlib import Path
 import shutil
 
+from .log import logger
+
 
 def load_setup_cfg():
     setup_cfg = configparser.ConfigParser()
@@ -11,16 +13,14 @@ def load_setup_cfg():
 
 def find_files(globs, service):
     files = []
+    log = logger()
 
     for glob in globs:
         matches = map(str, Path().glob(glob))
         files += list(matches)
 
-    print('Uploading to {}:'.format(service))
-    for filename in files:
-        print('- {}'.format(filename))
-    print('')
-
+    # NOTE: This is the wrong place for this log call
+    log.info('Uploading to %s: %s', service, ', '.join(files))
     return files
 
 

--- a/bork/github.py
+++ b/bork/github.py
@@ -8,8 +8,11 @@ from .asset_manager import download_assets
 
 
 def upload(*globs, dry_run=False):
-    # files = find_files(globs, 'GitHub')
-
+    # files = find_files(globs)
+    # logger().info("Uploading files to Github: %s",
+    #               ', '.join(("'{}'".format(file) for file in files)),
+    # )
+    #
     # if dry_run:
     #     logger().info('Skipping GitHub upload step since this is a dry run.')
     # else:

--- a/bork/github.py
+++ b/bork/github.py
@@ -11,7 +11,7 @@ def upload(*globs, dry_run=False):
     # files = find_files(globs, 'GitHub')
 
     # if dry_run:
-    #     logger().note('Skipping GitHub upload step since this is a dry run.')
+    #     logger().info('Skipping GitHub upload step since this is a dry run.')
     # else:
     #     pass
 

--- a/bork/github.py
+++ b/bork/github.py
@@ -3,6 +3,7 @@ import json
 from urllib.request import urlopen
 
 from .asset_manager import download_assets
+# from .log import logger
 # from .filesystem import find_files
 
 
@@ -10,7 +11,7 @@ def upload(*globs, dry_run=False):
     # files = find_files(globs, 'GitHub')
 
     # if dry_run:
-    #     print('NOTE: Skipping GitHub upload step since this is a dry run.')
+    #     logger().note('Skipping GitHub upload step since this is a dry run.')
     # else:
     #     pass
 

--- a/bork/log.py
+++ b/bork/log.py
@@ -1,13 +1,17 @@
 import inspect
 import logging
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Optional, TypeVar
 
 
-def logger() -> logging.Logger:
-    """Provide a logger with a name appropriate for the caller."""
-    caller = inspect.currentframe().f_back.f_code
-    # XXXTODO: Check this is truly correct
-    return logging.getLogger('bork.{}'.format(caller.co_name))
+def logger(context: Optional[inspect.FrameInfo] = None) -> logging.Logger:
+    """Provide a logger with a name appropriate for a given context.
+
+    The default context is the caller's.
+    """
+    if context is None:
+        context = inspect.getframeinfo(inspect.currentframe().f_back)
+
+    return logging.getLogger('bork.{}'.format(context.function))
 
 
 F = TypeVar('F', bound=Callable[..., Any])  # noqa

--- a/bork/log.py
+++ b/bork/log.py
@@ -1,6 +1,28 @@
 import inspect
 import logging
+import sys
 from typing import Any, Callable, Optional, TypeVar
+
+
+def _get_module(context: inspect.FrameInfo):
+    """Find the module name for a given FrameInfo.
+
+    Raises KeyError if the module isn't loaded.
+
+    Pilfered from Jamie Bliss' equivalent in pursuedpybear:
+      https://github.com/ppb/pursuedpybear/blob/master/ppb/utils.py
+    """
+    if context.filename not in _get_module.index:
+        _get_module.index = {
+            mod.__file__: mod.__name__
+            for mod in sys.modules.values()
+            if hasattr(mod, '__file__') and hasattr(mod, '__name__')
+        }
+
+    return _get_module.index[context.filename]
+
+
+_get_module.index = {}
 
 
 def logger(context: Optional[inspect.FrameInfo] = None) -> logging.Logger:
@@ -11,7 +33,7 @@ def logger(context: Optional[inspect.FrameInfo] = None) -> logging.Logger:
     if context is None:
         context = inspect.getframeinfo(inspect.currentframe().f_back)
 
-    return logging.getLogger('bork.{}'.format(context.function))
+    return logging.getLogger('{}.{}'.format(_get_module(context), context.function))
 
 
 F = TypeVar('F', bound=Callable[..., Any])

--- a/bork/log.py
+++ b/bork/log.py
@@ -14,7 +14,7 @@ def logger(context: Optional[inspect.FrameInfo] = None) -> logging.Logger:
     return logging.getLogger('bork.{}'.format(context.function))
 
 
-F = TypeVar('F', bound=Callable[..., Any])  # noqa
+F = TypeVar('F', bound=Callable[..., Any])
 
 
 def trace(func: F, level: int = logging.DEBUG) -> F:

--- a/bork/log.py
+++ b/bork/log.py
@@ -19,7 +19,7 @@ F = TypeVar('F', bound=Callable[..., Any])  # noqa
 
 def trace(func: F, level: int = logging.DEBUG) -> F:
     """Decorator to log function entry and exit."""
-    log = logging.getLogger(__name__ + func.__name__)
+    log = logging.getLogger('{}.{}'.format(func.__module__, func.__qualname__))
 
     def wrapper(*args, **kwargs):
         arglist = map(repr, args) + [

--- a/bork/log.py
+++ b/bork/log.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any, Callable, Optional, TypeVar
 
 
-def _get_module(context: inspect.FrameInfo):
+def _get_module(context: inspect.FrameInfo) -> str:
     """Find the module name for a given FrameInfo.
 
     Raises KeyError if the module isn't loaded.

--- a/bork/log.py
+++ b/bork/log.py
@@ -22,7 +22,9 @@ def trace(func: F, level: int = logging.DEBUG) -> F:
     log = logging.getLogger(__name__ + func.__name__)
 
     def wrapper(*args, **kwargs):
-        arglist = args + ['{}={}'.format(k, v) for k, v in kwargs]
+        arglist = map(repr, args) + [
+            '{}={}'.format(repr(k), repr(v)) for k, v in kwargs
+        ]
 
         try:
             log.log(level, 'called with %s', ', '.join(arglist))

--- a/bork/log.py
+++ b/bork/log.py
@@ -1,0 +1,29 @@
+import inspect
+import logging
+from typing import Any, Callable, TypeVar
+
+
+def logger() -> logging.Logger:
+    """Provide a logger with a name appropriate for the caller."""
+    caller = inspect.currentframe().f_back.f_code
+    # XXXTODO: Check this is truly correct
+    return logging.getLogger('bork.{}'.format(caller.co_name))
+
+
+F = TypeVar('F', bound=Callable[..., Any])  # noqa
+
+
+def trace(func: F, level: int = logging.DEBUG) -> F:
+    """Decorator to log function entry and exit."""
+    log = logging.getLogger(__name__ + func.__name__)
+
+    def wrapper(*args, **kwargs):
+        arglist = args + ['{}={}'.format(k, v) for k, v in kwargs]
+
+        try:
+            log.log(level, 'called with %s', ', '.join(arglist))
+            return func(*args, **kwargs)
+        finally:
+            log.log(level, 'exiting')
+
+    return wrapper

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -2,6 +2,7 @@ from twine.cli import dispatch as twine_upload
 
 from .asset_manager import download_assets
 from .filesystem import find_files
+from .log import logger
 from .pypi_api import get_download_info
 
 
@@ -13,7 +14,7 @@ class PypiHandler:
         files = find_files(globs, 'PyPI')
 
         if dry_run:
-            print('NOTE: Skipping PyPI upload step since this is a dry run.')
+            logger().note('Skipping PyPI upload step since this is a dry run.')
         else:
             twine_upload(['upload', '--repository-url', self.repo_url, *files])
 

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -11,7 +11,11 @@ class PypiHandler:
         self.repo_url = repo_url
 
     def upload(self, *globs, dry_run=False):
-        files = find_files(globs, 'PyPI')
+        files = find_files(globs)
+        logger().info("Uploading files to PyPI instance '%s': %s",
+                      self.repo_url,
+                      ', '.join(("'{}'".format(file) for file in files)),
+        )
 
         if dry_run:
             logger().info('Skipping PyPI upload step since this is a dry run.')

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -12,9 +12,10 @@ class PypiHandler:
 
     def upload(self, *globs, dry_run=False):
         files = find_files(globs)
-        logger().info("Uploading files to PyPI instance '%s': %s",
-                      self.repo_url,
-                      ', '.join(("'{}'".format(file) for file in files)),
+        logger().info(
+            "Uploading files to PyPI instance '%s': %s",
+            self.repo_url,
+            ', '.join(("'{}'".format(file) for file in files)),
         )
 
         if dry_run:

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -14,7 +14,7 @@ class PypiHandler:
         files = find_files(globs, 'PyPI')
 
         if dry_run:
-            logger().note('Skipping PyPI upload step since this is a dry run.')
+            logger().info('Skipping PyPI upload step since this is a dry run.')
         else:
             twine_upload(['upload', '--repository-url', self.repo_url, *files])
 


### PR DESCRIPTION
This is built around Python's standard `logging` library, so it should do the right thing even if `bork` was used as a library.

- [x] Added a `log` module for structured logging helpers:
  - `logger` provides a `logging.Logger` object appropriate for its caller's context (correct name set, ...);
  - `trace` is a decorator for automatically logging (defaults to debug level) function entry, arguments, and exit;
- [x] Replaced all calls to `print` with structured logging:
  - tells us which function is logging info,
  - lets us filter by level,
  - can easily be suppressed or redirected to a logfile;
- [x] Replaced calls to `sys.exit` with exceptions:
  - can be caught by API users,
  - the CLI frontend provides details (like a trace) in verbose mode.