### PR TITLE
Make the Github module more robust

### DIFF
--- a/bork/github.py
+++ b/bork/github.py
@@ -49,11 +49,15 @@ def _get_download_info(repo, name, file_pattern, draft=False, prerelease=False):
         else:
             releases.append(release)
 
-    if name == 'latest':
-        release = sorted(releases, key=lambda x: x['created_at'])[-1]
-        log.info("Selected release '%s' as latest", release['name'])
-    else:
-        release = list(filter(lambda x: x['tag_name'] == name, releases))[0]
+    try:
+        if name == 'latest':
+            release = sorted(releases, key=lambda x: x['created_at'])[-1]
+            log.info("Selected release '%s' as latest", release['name'])
+        else:
+            release = list(filter(lambda x: x['tag_name'] == name, releases))[0]
+
+    except IndexError as e:
+        raise RuntimeError("No such Github release: '{}'".format(name)) from e
 
     all_assets = release['assets']
 

--- a/bork/github.py
+++ b/bork/github.py
@@ -52,8 +52,10 @@ def _get_release_info(repo, name, draft=False, prerelease=False):
 
     try:
         if name == 'latest':
-            release = sorted(releases,
-                             key=lambda x: LooseVersion(x['tag_name'].lstrip('v')))[-1]
+            release = max(
+                releases,
+                key=lambda x: LooseVersion(x['tag_name'].lstrip('v')),
+            )
             log.info("Selected release '%s' as latest", release['name'])
         else:
             release = list(filter(lambda x: x['tag_name'] == name, releases))[0]

--- a/bork/github.py
+++ b/bork/github.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import fnmatch
 import json
 from urllib.request import urlopen
@@ -51,7 +52,8 @@ def _get_release_info(repo, name, draft=False, prerelease=False):
 
     try:
         if name == 'latest':
-            release = sorted(releases, key=lambda x: x['created_at'])[-1]
+            release = sorted(releases,
+                             key=lambda x: LooseVersion(x['tag_name'].lstrip('v')))[-1]
             log.info("Selected release '%s' as latest", release['name'])
         else:
             release = list(filter(lambda x: x['tag_name'] == name, releases))[0]

--- a/bork/github.py
+++ b/bork/github.py
@@ -29,7 +29,7 @@ def _relevant_asset(asset, file_pattern):
     return False
 
 
-def _get_download_info(repo, name, file_pattern, draft=False, prerelease=False):
+def _get_release_info(repo, name, draft=False, prerelease=False):
     if '/' not in repo:
         raise ValueError(
             "repo must be of format <user>/<repo>, got '{}'".format(repo),
@@ -59,13 +59,11 @@ def _get_download_info(repo, name, file_pattern, draft=False, prerelease=False):
     except IndexError as e:
         raise RuntimeError("No such Github release: '{}'".format(name)) from e
 
-    all_assets = release['assets']
-
-    assets = filter(lambda x: _relevant_asset(x, file_pattern), all_assets)
-
-    return assets
+    return release
 
 
 def download(repo, release, file_pattern, directory):
-    asset_list = _get_download_info(repo, release, file_pattern)
-    download_assets(asset_list, directory, url_key='browser_download_url')
+    release_info = _get_release_info(repo, release, file_pattern)
+    assets = filter(lambda x: _relevant_asset(x, file_pattern),
+                    release_info['assets'])
+    download_assets(assets, directory, url_key='browser_download_url')


### PR DESCRIPTION
- [x] Filter prereleases and draft releases by default.
  Those are probably not desired behaviour unless explicitely requested.
- [x] Gracefully handle inexistent releases.
- [x] Make the `latest` release resolve to the one with the highest version number, not the one released last (some projects maintain multiple concurrent release streams)
- [x] Generalise `_get_download_info`, which will be needed to implement upload robustly (