### PR TITLE
Add trailing / to PyPi URLs

### DIFF
--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -28,5 +28,5 @@ class PypiHandler:
         download_assets(asset_list, directory)
 
 
-PRODUCTION = PypiHandler('https://pypi.org/simple')
-TESTING = PypiHandler('https://test.pypi.org/simple')
+PRODUCTION = PypiHandler('https://pypi.org/simple/')
+TESTING = PypiHandler('https://test.pypi.org/simple/')

--- a/bork/pypi_api.py
+++ b/bork/pypi_api.py
@@ -67,6 +67,10 @@ def _matches_version(filename, version):
 def get_download_info(base_url, package, release, file_pattern):
     results = []
 
+    # Normalize base_url so it never ends with a forward slash.
+    if base_url.endswith('/'):
+        base_url = base_url[:-1]
+
     html = urlopen('{}/{}/'.format(base_url, package)).read().decode()
     parser = SimplePypiParser()
     parser.feed(html)


### PR DESCRIPTION
Add trailing / to PyPi URLs because apparently 'bork release' got broken by `/simple` redirecting to `/simple/` on PyPI?