### PR TITLE
GitHub Release support, part 2

### DIFF
--- a/bork/github.py
+++ b/bork/github.py
@@ -4,20 +4,28 @@ import json
 from urllib.request import urlopen
 
 from .asset_manager import download_assets
+from .filesystem import find_files
 from .log import logger
-# from .filesystem import find_files
 
 
-def upload(*globs, dry_run=False):
-    # files = find_files(globs)
-    # logger().info("Uploading files to Github: %s",
-    #               ', '.join(("'{}'".format(file) for file in files)),
-    # )
-    #
-    # if dry_run:
-    #     logger().info('Skipping GitHub upload step since this is a dry run.')
-    # else:
-    #     pass
+def upload(*globs, dry_run=False, strip_zipapp_version=False):
+    log = logger()
+
+    files = find_files(globs)
+
+    log.info('Uploading files to Github.')
+    for filename in files:
+        if strip_zipapp_version and filename.endswith('.pyz'):
+            dest_filename = '-'.join(filename.split('-')[:-1]) + '.pyz'
+            log.info('- %s as %s', filename, dest_filename)
+        else:
+            dest_filename = filename
+            log.info('- %s', filename)
+
+    if dry_run:
+        log.info('Skipping GitHub upload step since this is a dry run.')
+    else:
+        pass
 
     raise NotImplementedError('github.upload() is not yet implemented')
 

--- a/bork/github.py
+++ b/bork/github.py
@@ -23,9 +23,8 @@ def upload(*globs, dry_run=False, strip_zipapp_version=False):
             log.info('- %s', filename)
 
     if dry_run:
-        log.info('Skipping GitHub upload step since this is a dry run.')
-    else:
-        pass
+        log.warn('Skipping GitHub upload step since this is a dry run.')
+        return
 
     raise NotImplementedError('github.upload() is not yet implemented')
 

--- a/bork/github.py
+++ b/bork/github.py
@@ -23,7 +23,7 @@ def upload(*globs, dry_run=False, strip_zipapp_version=False):
             log.info('- %s', filename)
 
     if dry_run:
-        log.warn('Skipping GitHub upload step since this is a dry run.')
+        log.warning('Skipping GitHub upload step since this is a dry run.')
         return
 
     raise NotImplementedError('github.upload() is not yet implemented')

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -20,7 +20,7 @@ class PypiHandler:
         )
 
         if dry_run:
-            logger().info('Skipping PyPI upload step since this is a dry run.')
+            logger().warning('Skipping PyPI upload step since this is a dry run.')
         else:
             twine_upload(['upload', '--repository-url', self.upload_url, *files])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ build-backend = "setuptools.build_meta"
 enabled = true
 main = "bork.cli:zipapp_main"
 
+[tool.bork.release]
+pypi = true
+github = true
+strip_zipapp_version = true
+
 [tool.bork.aliases]
 # Runs *only* pylint and flake8. (Not the actual tests.)
 lint = "pytest -k 'flake8 or pylint or mypy' --pylint --flake8 --mypy --verbose"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ main = "bork.cli:zipapp_main"
 
 [tool.bork.release]
 pypi = true
-github = true
+github = false
 strip_zipapp_version = true
 
 [tool.bork.aliases]


### PR DESCRIPTION
Related: #57. 

Part 2 of implementing #3. 

This gets use to the point of knowing what files would be uploaded to GitHub and raising a `NotImplementedError` instead of actually uploading it. This means `bork release --dry-run` works, but just `bork release` will not.