### PR TITLE
Add a stub setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Add a stub `setup.py`

This is required for editable installs. Which I use extensively, because I have a lot of venvs and sometimes I want my live development version.