### PR TITLE
Add type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.eggs/
+/.mypy_cache/
 /.pytest_cache/
 /.tox/
 /build/

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -5,7 +5,7 @@ import sys
 # Slight kludge so we can have a function named zipapp().
 import zipapp as Zipapp  # noqa: N812
 
-import pep517.build
+import pep517.build  # type: ignore
 import toml
 
 from .filesystem import load_setup_cfg, try_delete

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -72,7 +72,9 @@ def main():
         sys.exit()
 
     try:
-        import coloredlogs  # pylint: disable=import-outside-toplevel
+        # pylint: disable=import-outside-toplevel
+        import coloredlogs  # type: ignore
+        # pylint: enable=import-outside-toplevel
         coloredlogs.install(
             level=logging.INFO if verbose else logging.WARNING,
             fmt="%(name)s %(levelname)s %(message)s",

--- a/bork/log.py
+++ b/bork/log.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any, Callable, cast, Dict, Optional, TypeVar
 
 
-#+: Index mapping file names to module names.
+# Index mapping file names to module names.
 _module_index: Dict[str, str] = {}
 
 

--- a/bork/log.py
+++ b/bork/log.py
@@ -1,8 +1,11 @@
 import inspect
 import logging
 import sys
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Dict, Optional, TypeVar
 
+
+#+: Index mapping file names to module names.
+_module_index: Dict[str, str] = {}
 
 def _get_module(context: inspect.FrameInfo) -> str:
     """Find the module name for a given FrameInfo.
@@ -12,17 +15,14 @@ def _get_module(context: inspect.FrameInfo) -> str:
     Pilfered from Jamie Bliss' equivalent in pursuedpybear:
       https://github.com/ppb/pursuedpybear/blob/master/ppb/utils.py
     """
-    if context.filename not in _get_module.index:
-        _get_module.index = {
+    if context.filename not in _module_index:
+        _module_index = {
             mod.__file__: mod.__name__
             for mod in sys.modules.values()
             if hasattr(mod, '__file__') and hasattr(mod, '__name__')
         }
 
-    return _get_module.index[context.filename]
-
-
-_get_module.index = {}
+    return _module_index[context.filename]
 
 
 def logger(context: Optional[inspect.FrameInfo] = None) -> logging.Logger:

--- a/bork/log.py
+++ b/bork/log.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 import sys
-from typing import Any, Callable, Dict, Optional, TypeVar
+from typing import Any, Callable, cast, Dict, Optional, TypeVar
 
 
 #+: Index mapping file names to module names.
@@ -54,4 +54,6 @@ def trace(func: F, level: int = logging.DEBUG) -> F:
         finally:
             log.log(level, 'exiting')
 
-    return wrapper
+    # Cast required, as mypy cannot (yet?) type decorators usefully:
+    #  https://github.com/python/mypy/issues/3157
+    return cast(F, wrapper)

--- a/bork/log.py
+++ b/bork/log.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, cast, Dict, Optional, TypeVar
 #+: Index mapping file names to module names.
 _module_index: Dict[str, str] = {}
 
+
 def _get_module(context: inspect.FrameInfo) -> str:
     """Find the module name for a given FrameInfo.
 
@@ -15,6 +16,7 @@ def _get_module(context: inspect.FrameInfo) -> str:
     Pilfered from Jamie Bliss' equivalent in pursuedpybear:
       https://github.com/ppb/pursuedpybear/blob/master/ppb/utils.py
     """
+    global _module_index  # pylint: disable=global-statement
     if context.filename not in _module_index:
         _module_index = {
             mod.__file__: mod.__name__

--- a/bork/log.py
+++ b/bork/log.py
@@ -33,7 +33,12 @@ def logger(context: Optional[inspect.FrameInfo] = None) -> logging.Logger:
     The default context is the caller's.
     """
     if context is None:
-        context = inspect.getframeinfo(inspect.currentframe().f_back)
+        context = inspect.getframeinfo(inspect.currentframe().f_back)  # type: ignore
+
+    if context is None:
+        # This may not be the best way to handle it, but if we get here
+        # it'll avoid causing errors, at least.
+        return logging.getLogger('??.??')
 
     return logging.getLogger('{}.{}'.format(_get_module(context), context.function))
 

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -1,4 +1,4 @@
-from twine.cli import dispatch as twine_upload
+from twine.cli import dispatch as twine_upload  # type: ignore
 
 from .asset_manager import download_assets
 from .filesystem import find_files

--- a/bork/pypi_api.py
+++ b/bork/pypi_api.py
@@ -1,11 +1,12 @@
 import fnmatch
 from html.parser import HTMLParser
 import re
+from typing import Dict
 from urllib.request import urlopen
 
 
 class SimplePypiParser(HTMLParser):
-    files = {}
+    files: Dict[str, str] = {}
     in_anchor = False
     current_url = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,6 @@ main = "bork.cli:zipapp_main"
 
 [tool.bork.aliases]
 # Runs *only* pylint and flake8. (Not the actual tests.)
-lint = "pytest -k 'flake8 or pylint' --pylint --flake8 --verbose"
+lint = "pytest -k 'flake8 or pylint or mypy' --pylint --flake8 --mypy --verbose"
 # Runs tests, pylint, and flake8.
-test = "pytest --pylint --flake8 --verbose"
+test = "pytest --pylint --flake8 --mypy --verbose"

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ testing =
     pytest==5.4.1
     pytest-flake8==1.0.4
     pytest-pylint==0.15.1
-    pytest-mypy==0.4.1
+    pytest-mypy==0.6.0
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ testing =
     pytest==5.4.1
     pytest-flake8==1.0.4
     pytest-pylint==0.15.1
+    pytest-mypy==0.4.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,12 @@ testing =
     flake8-import-order==0.18.1
     pep8-naming==0.10.0
     pylint==2.4.4
-    pytest==5.4.1
+    # pytest is pinned to 5.3.5, not latest, because of deprecation warnings.
+    # When these 3 issues are resolved, we can pin to latest again:
+    # - https://github.com/dbader/pytest-mypy/pull/82
+    # - https://github.com/tholo/pytest-flake8/issues/63
+    # - https://github.com/carsongee/pytest-pylint/issues/120
+    pytest==5.3.5
     pytest-flake8==1.0.4
     pytest-pylint==0.15.1
     pytest-mypy==0.6.0

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,3 @@
-from setuptools import setup
+from setuptools import setup  # type: ignore
 
 setup()


### PR DESCRIPTION
Based on #71 by @nbraud.

TODO (copy/pasted from #71):
- [x] Setup `bork` and `setuptools` to run the `mypy` typechecker during linting.
- [x] Add `type: ignore` annotations when importing modules that do not have type definitions.
  In the long run, this ought to be fixed by teaching `mypy` about those modules.
- [x] Fix import of `coloredlogs`
  Unsure how to have both a `pylint` and `type` directive in the same comment.
- [x] Add annotations for `log.{_get_module, trace}`
- [x] Get `log.logger` to typecheck.

Closes #62 