### PR TITLE
Override $LANG environment variable if needed.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,11 +2,6 @@
 # master, staging, and trying branches. (So bors can use them.)
 use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true' || $CIRRUS_BRANCH == 'master' || $CIRRUS_BRANCH == 'staging' || $CIRRUS_BRANCH == 'trying'
 
-# This makes Click behave itself.
-env:
-  LC_ALL: C.UTF-8
-  LANG: C.UTF-8
-
 Lint_task:
   container:
     image: python:3.8-slim

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -10,6 +10,17 @@ from . import __version__
 from . import api
 from .log import logger
 
+try:
+    from click._unicodefun import _verify_python3_env  # type: ignore
+    _verify_python3_env()
+except RuntimeError:
+    # Kludge to fix environment for Click.
+    # If we ever switch away from Click, this can probably be removed.
+    os.environ['LANG'] = 'C.UTF-8'
+    os.environ['LC_ALL'] = 'C.UTF-8'
+    os.execvpe(sys.argv[0], sys.argv, os.environ)
+    raise
+
 
 DOWNLOAD_SOURCES_STR = ' '.join(api.DOWNLOAD_SOURCES)
 


### PR DESCRIPTION
This is a Click-specific kludge. If we ever switch away from Click, it can probably be removed.

Fixes #185.