### PR TITLE
run: Deal with lists being put in the configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ if you put this in pyproject.toml:
 ```toml
 [tool.bork.aliases]
 # Runs *only* pylint. (Not the actual tests.)
-lint = "pytest -k 'pylint' --pylint --verbose"
+lint = [
+	# Runs *only* pylint. (Not the actual tests.)
+	"pytest -k 'pylint' --pylint --verbose",
+	# Typecheck the project
+	"mypy .",
+]
 # Runs tests and pylint.
 test = "pytest --pylint --verbose"
 test-only = "pytest --verbose"

--- a/bork/api.py
+++ b/bork/api.py
@@ -105,14 +105,23 @@ def run(alias):
     pyproject = toml.load('pyproject.toml')
 
     try:
-        command = pyproject['tool']['bork']['aliases'][alias]
+        commands = pyproject['tool']['bork']['aliases'][alias]
     except KeyError as error:
         raise RuntimeError("No such alias: '{}'".format(alias)) from error
 
-    logger().info("Running '%s'", command)
+    logger().info("Running '%s'", commands)
+
+    if isinstance(commands, str):
+        commands = [commands]
+    elif isinstance(commands, list):
+        pass
+    else:
+        raise TypeError(f"commands must be str or list, was {type(commands)}")
 
     try:
-        subprocess.run(command, check=True, shell=True)
+        for command in commands:
+            print(command)
+            subprocess.run(command, check=True, shell=True)
 
     except subprocess.CalledProcessError as error:
         if error.returncode < 0:


### PR DESCRIPTION
I just noticed that Bork will accept lists, in command definitions, and pass them to `subprocess.run`, which seems to silently discard all but the first element.

It seemed sensible to interpret it instead as a list of commands to execute sequentially; doing it in parallel could be cute, but also rather silly  >_>'

If this seems like a bad idea, please make sure that lists are rejected instead.
The current situation is just very confusing.  :3