### PR TITLE
Update CI for new Python versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -71,13 +71,13 @@ macOS_task:
     LANG: en_US.UTF-8
     PATH: ${HOME}/.pyenv/shims:${PATH}
     matrix:
-      - PYTHON: 3.6.8
-      - PYTHON: 3.7.2
+      - PYTHON: 3.6.9
+      - PYTHON: 3.7.9
       - PYTHON: 3.8.6
       - PYTHON: 3.9.0
   install_script:
     # Per the pyenv homebrew recommendations.
-    # https://github.com/pyenv/pyenv/wiki#suggested-build-environment
+    #  https://github.com/pyenv/pyenv/wiki#suggested-build-environment
     - brew install openssl readline pyenv git
     - pyenv install ${PYTHON}
     - pyenv global ${PYTHON}

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,6 +22,7 @@ Zipapp_bootstrap_task:
     matrix:
       image: python:3.7-slim
       image: python:3.8-slim
+      image: python:3.9-slim
   setup_script:
     - cp -r . /tmp/bork-pristine
     - cp -r /tmp/bork-pristine /tmp/pass1
@@ -53,6 +54,7 @@ Linux_task:
       - image: python:3.6-slim
       - image: python:3.7-slim
       - image: python:3.8-slim
+      - image: python:3.9-slim
   install_script:
     - apt-get update
     - apt-get install -y git
@@ -71,6 +73,7 @@ macOS_task:
     matrix:
       - PYTHON: 3.6.8
       - PYTHON: 3.7.2
+      - PYTHON: 3.9.0
   install_script:
     # Per the pyenv homebrew recommendations.
     # https://github.com/pyenv/pyenv/wiki#suggested-build-environment

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,6 +73,7 @@ macOS_task:
     matrix:
       - PYTHON: 3.6.8
       - PYTHON: 3.7.2
+      - PYTHON: 3.8.6
       - PYTHON: 3.9.0
   install_script:
     # Per the pyenv homebrew recommendations.
@@ -93,6 +94,7 @@ FreeBSD_task:
     matrix:
       - PYTHON: 3.6
       - PYTHON: 3.7
+      - PYTHON: 3.8
   install_script:
     - PY=`echo $PYTHON | tr -d '.'`
     - pkg install -y python${PY} py${PY}-setuptools git

--- a/bors.toml
+++ b/bors.toml
@@ -5,10 +5,13 @@ status = [
   "Linux container:python:3.6-slim",
   "Linux container:python:3.7-slim",
   "Linux container:python:3.8-slim",
+  "Linux container:python:3.9-slim",
   "Zipapp_bootstrap container:python:3.7-slim",
   "Zipapp_bootstrap container:python:3.8-slim",
+  "Zipapp_bootstrap container:python:3.9-slim",
   "macOS PYTHON:3.6.8",
   "macOS PYTHON:3.7.2",
+  "macOS PYTHON:3.9.0",
 ]
 
 delete_merged_branches = true

--- a/bors.toml
+++ b/bors.toml
@@ -10,8 +10,8 @@ status = [
   "Zipapp_bootstrap container:python:3.7-slim",
   "Zipapp_bootstrap container:python:3.8-slim",
   "Zipapp_bootstrap container:python:3.9-slim",
-  "macOS PYTHON:3.6.8",
-  "macOS PYTHON:3.7.2",
+  "macOS PYTHON:3.6.9",
+  "macOS PYTHON:3.7.9",
   "macOS PYTHON:3.8.6",
   "macOS PYTHON:3.9.0",
 ]

--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,7 @@
 status = [
   "FreeBSD PYTHON:3.6",
   "FreeBSD PYTHON:3.7",
+  "FreeBSD PYTHON:3.8",
   "Lint",
   "Linux container:python:3.6-slim",
   "Linux container:python:3.7-slim",
@@ -11,6 +12,7 @@ status = [
   "Zipapp_bootstrap container:python:3.9-slim",
   "macOS PYTHON:3.6.8",
   "macOS PYTHON:3.7.2",
+  "macOS PYTHON:3.8.6",
   "macOS PYTHON:3.9.0",
 ]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 


### PR DESCRIPTION
- [x] Added Python 3.9 environments for Linux and macOS
- [ ] Add Python 3.9 environment for FreeBSD
      That's blocked on the `setuptools` port being updated to build for 3.9
- [x] Added missing Python 3.8 environments for FreeBSD and macOS
- [x] Updated the Python 3.6 and 3.7 envs on macOS to the latest supported by pyenv