### PR TITLE
Fix CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -44,8 +44,8 @@ Zipapp_bootstrap_task:
     - cd /tmp/pass3
     - cp /tmp/pass2/dist/bork-*.pyz /tmp/bork-pass2.pyz
     - python3 /tmp/bork-pass2.pyz build
-    - cp ./dist/bork-*.pyz /tmp/bork-pass3.pyz
-    - python3 /tmp/bork-pass3.pyz run lint
+    - '[ -e ./dist/bork-*.pyz ]'
+
 
 Linux_task:
   container:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -97,7 +97,7 @@ FreeBSD_task:
     - python${PYTHON} -m pip install -e .[testing_only]
   script:
     - python${PYTHON} --version
-    - bork run _test-only
+    - bork run test
 
 # Windows_task:
 #   allow_failures: $CIRRUS_TASK_NAME =~ '.*-rc-.*'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,9 @@ strip_zipapp_version = true
 [tool.bork.aliases]
 # Runs *only* pylint and mypy. (Not the actual tests.)
 lint = "pytest -k 'pylint or mypy' --pylint --mypy --verbose"
-# Runs all tests and pylint.
-test = "pytest --pylint --mypy --verbose"
-# Runs fast tests, and pylint.
-test-fast = "pytest --pylint --mypy --verbose -m 'not slow'"
+# Runs all tests.
+test = "pytest --verbose"
+# Runs fast tests.
+test-fast = "pytest --verbose -m 'not slow'"
 # Runs slow tests.
 test-slow = "pytest --verbose -m slow"
-# Runs fast tests and slow tests, but not pylint.
-_test-only = "pytest --verbose"

--- a/tests/test_cmd_aliases.py
+++ b/tests/test_cmd_aliases.py
@@ -4,4 +4,4 @@ from helpers import bork_cli
 def test_cmd_aliases():
     result = bork_cli("aliases")
     assert result.exit_code == 0
-    assert result.output == 'lint\ntest\ntest-fast\ntest-slow\n_test-only\n'
+    assert result.output == 'lint\ntest\ntest-fast\ntest-slow\n'


### PR DESCRIPTION
- [x] Stop running lints when running tests.
      Not only is this inefficient, it forces us to get linting working in all
      environments, which isn't currently possible (see PyCQA/pylint#3882).
      As a result, remove the `_test-only` task.
- [x] Don't run tests when bootstrapping Bork in CI
      - It is useless, as `python3 /tmp/bork...pyz run test` immediately shells
        out to pytest, and tests the version of bork that is on the filesystem.
      - It fails because `git` isn't installed.

Changes by @duckinator and myself, extracted from #233 and #234