### PR TITLE
Define “success” as a single CI task, refactor Bors & release config

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,6 +18,7 @@ Lint_task:
     - bork run lint
 
 Zipapp_bootstrap_task:
+  alias: Zipapp bootstraps
   container:
     matrix:
       image: python:3.7-slim
@@ -49,6 +50,7 @@ Zipapp_bootstrap_task:
 
 
 Linux_task:
+  alias: Linux tests
   container:
     matrix:
       - image: python:3.6-slim
@@ -64,6 +66,7 @@ Linux_task:
     - bork run test
 
 macOS_task:
+  alias: macOS tests
   osx_instance:
     image: catalina-xcode
   env:
@@ -88,6 +91,7 @@ macOS_task:
     - bork run test
 
 FreeBSD_task:
+  alias: FreeBSD tests
   freebsd_instance:
     image_family: freebsd-12-1-snap
   env:
@@ -119,16 +123,20 @@ FreeBSD_task:
 #     - C:\Python\python.exe --version
 #     - C:\Python\python.exe -m pytest --verbose
 
+success_task:
+  name: CI success
+  depends_on:
+    - FreeBSD tests
+    - Linux tests
+    - macOS tests
+    - Zipapp bootstraps
+    - Lint
+    #- Windows
+
 # If bork/version.py is modified on the master branch, make a release.
 Release_task:
   only_if: "changesInclude('bork/version.py') && $BRANCH == 'master' && $CIRRUS_CRON == ''"
-  depends_on:
-    - Lint
-    - Zipapp_bootstrap
-    - Linux
-    - macOS
-    - FreeBSD
-    #- Windows
+  depends_on: [CI success]
   env:
     TWINE_USERNAME: "__token__"
     TWINE_PASSWORD: ENCRYPTED[00007524e18bea7b59efea288653efa57b1dbd235ed8af00cc325febfc9076631a2bf58ed330d8fa7ca057adb81579b0]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -125,6 +125,7 @@ FreeBSD_task:
 
 success_task:
   name: CI success
+  container: {image: "busybox"}
   depends_on:
     - FreeBSD tests
     - Linux tests

--- a/bors.toml
+++ b/bors.toml
@@ -1,19 +1,3 @@
-status = [
-  "FreeBSD PYTHON:3.6",
-  "FreeBSD PYTHON:3.7",
-  "FreeBSD PYTHON:3.8",
-  "Lint",
-  "Linux container:python:3.6-slim",
-  "Linux container:python:3.7-slim",
-  "Linux container:python:3.8-slim",
-  "Linux container:python:3.9-slim",
-  "Zipapp_bootstrap container:python:3.7-slim",
-  "Zipapp_bootstrap container:python:3.8-slim",
-  "Zipapp_bootstrap container:python:3.9-slim",
-  "macOS PYTHON:3.6.9",
-  "macOS PYTHON:3.7.9",
-  "macOS PYTHON:3.8.6",
-  "macOS PYTHON:3.9.0",
-]
+status = [ "CI success" ]
 
 delete_merged_branches = true


### PR DESCRIPTION
- [x] Introduced aliases for each task group
- [x] Introduced a “CI success” task that depends on all relevant tasks
- [x] Refactored the Bors config and release task to depend on that task

Closes #236