### PR TITLE
CI: Add FreeBSD CI for Python 3.9

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -105,7 +105,7 @@ FreeBSD_task:
       - PYTHON: 3.8
   install_script:
     - PY=`echo $PYTHON | tr -d '.'`
-    - pkg install -y python${PY} py${PY}-setuptools git
+    - pkg install -y python${PY} git
     - python${PYTHON} -m ensurepip
     - python${PYTHON} -m pip install -U --upgrade-strategy eager pip 'setuptools>42'
     - python${PYTHON} -m pip install -e .[testing_only]

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -103,6 +103,7 @@ FreeBSD_task:
       - PYTHON: 3.6
       - PYTHON: 3.7
       - PYTHON: 3.8
+      - PYTHON: 3.9
   install_script:
     - PY=`echo $PYTHON | tr -d '.'`
     - pkg install -y python${PY} git


### PR DESCRIPTION
Now that we install `setuptools` from PyPI, the blocker to FreeBSD/Py3.9 CI,
which was a build of the `py39-setuptools` port, is irrelevant.