### PR TITLE
Be more helpful when pyproject.toml is missing

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -50,7 +50,7 @@ def build():
 
         logger().error(
             "You need a 'pyproject.toml' file describing which buildsystem to "
-            "use, per PEP 517. " + msg
+            "use, per PEP 517. %s", msg
         )
 
         raise e

--- a/bork/api.py
+++ b/bork/api.py
@@ -41,10 +41,10 @@ def build():
         if setup("cfg").exists() or setup("py").exists():
             msg = """If you use setuptools, the following should be sufficient:
 
-            	[build-system]
-            	requires = ["setuptools > 42", "wheel"]
-            	build-backend = "setuptools.build_meta"
-            """
+	[build-system]
+	requires = ["setuptools > 42", "wheel"]
+	build-backend = "setuptools.build_meta" """
+
         else:
             msg = "Please refer to your build system's documentation."
 

--- a/bork/api.py
+++ b/bork/api.py
@@ -28,8 +28,32 @@ def aliases():
 
 
 def build():
-    builder.dist()
-    builder.zipapp()
+    try:
+        builder.dist()
+        builder.zipapp()
+
+    except FileNotFoundError as e:
+        if e.filename != 'pyproject.toml':
+            raise e
+
+        setup = lambda ext: Path.cwd() / f"setup.{ext}"
+
+        if setup("cfg").exists() or setup("py").exists():
+            msg = """If you use setuptools, the following should be sufficient:
+
+            	[build-system]
+            	requires = ["setuptools > 42", "wheel"]
+            	build-backend = "setuptools.build_meta"
+            """
+        else:
+            msg = "Please refer to your build system's documentation."
+
+        logger().error(
+            "You need a 'pyproject.toml' file describing which buildsystem to "
+            "use, per PEP 517. " + msg
+        )
+
+        raise e
 
 
 def clean():


### PR DESCRIPTION
- [x] Emit an error referring to PEP 517 and to the buildsystem's documentation.
- [x] When the `setup.py` style is detected, suggest a basic `pyproject.toml`.
- [ ] Improve bork's error display, to ensure error messages aren't pushed off-screen by a backtrace.