### PR TITLE
Add a `dependencies` command, which dumps the list of dependencies

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -4,6 +4,7 @@ from signal import Signals
 import subprocess
 import sys
 
+import pep517  # type:ignore
 import toml
 
 from . import builder
@@ -38,6 +39,11 @@ def clean():
     for name in Path.cwd().glob('*.egg-info'):
         if name.is_dir():
             try_delete(name)
+
+
+def dependencies():
+    """Get the list of dependencies."""
+    return pep517.meta.load('.').metadata.get_all('Requires-Dist')
 
 
 def download(package, release_tag, file_pattern, directory):

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -41,6 +41,14 @@ def clean():
 
 
 @cli.command()
+@click.option('-o', '--output', type=click.File('w'), default='-',
+              help='File in which to save the list of dependencies.')
+def dependencies(output):
+    for dep in api.dependencies():
+        print(dep, file=output)
+
+
+@cli.command()
 @click.option('--files', default='*.pyz',
               help='Comma-separated list of filenames to download. Supports '
                    'wildcards (* = everything, ? = any single character).')

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ python_requires = >=3.6
 install_requires =
     wheel==0.36.2
     build==0.1.0
+    pep517==0.9.1
     packaging==20.8
     toml==0.10.2
     twine==3.3.0


### PR DESCRIPTION
This is useful for automating things like installing only a project's
dependencies.  The specific usecase I just ran into, was generating container
images for CI with all dependencies preinstalled.

Obviously, this doesn't work well with pipelines that trigger actions if a file
changed in the source repo, but it's still much better than nothing.