### PR TITLE
Handle the case of a legacy project.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -24,7 +24,8 @@ disable=missing-docstring,
         bad-continuation,
         len-as-condition,
         compare-to-zero,
-        invalid-name
+        invalid-name,
+        no-else-return
 
 
 [REPORTS]

--- a/bork/api.py
+++ b/bork/api.py
@@ -5,12 +5,11 @@ import subprocess
 import sys
 
 import pep517  # type:ignore
-import toml
 
 from . import builder
 from . import github
 from . import pypi
-from .filesystem import try_delete
+from .filesystem import try_delete, load_pyproject
 from .log import logger
 
 
@@ -24,7 +23,7 @@ DOWNLOAD_SOURCES = {
 
 
 def aliases():
-    pyproject = toml.loads(Path('pyproject.toml').read_text())
+    pyproject = load_pyproject()
     return pyproject.get('tool', {}).get('bork', {}).get('aliases', {})
 
 
@@ -87,7 +86,7 @@ def download(package, release_tag, file_pattern, directory):
 
 
 def release(repository_name, dry_run):
-    pyproject = toml.load('pyproject.toml')
+    pyproject = load_pyproject()
     bork_config = pyproject.get('tool', {}).get('bork', {})
     release_config = bork_config.get('release', {})
     github_token = os.environ.get('BORK_GITHUB_TOKEN', None)
@@ -132,7 +131,7 @@ def release(repository_name, dry_run):
 
 
 def run(alias):
-    pyproject = toml.load('pyproject.toml')
+    pyproject = load_pyproject()
 
     try:
         commands = pyproject['tool']['bork']['aliases'][alias]

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -5,9 +5,8 @@ import sys
 import zipapp as Zipapp  # noqa: N812
 
 import build
-import toml
 
-from .filesystem import load_setup_cfg, try_delete
+from .filesystem import load_setup_cfg, load_pyproject, try_delete
 from .log import logger
 
 
@@ -67,7 +66,7 @@ def zipapp():
     dist() should be called before zipapp().
     """
 
-    pyproject = toml.load('pyproject.toml')
+    pyproject = load_pyproject()
     config = pyproject.get('tool', {}).get('bork', {})
     zipapp_cfg = config.get('zipapp', {})
     want_zipapp = zipapp_cfg.get('enabled', False)

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -29,7 +29,8 @@ def load_pyproject():
                     'requires': ['setuptools>=42'],
                 },
             }
-        else:
+        else:  # noqa: R1705
+            # Can't figure out what kind of project it is.
             raise
 
 

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -29,7 +29,7 @@ def load_pyproject():
                     'requires': ['setuptools>=42'],
                 },
             }
-        else:  # noqa: R1705
+        else:
             # Can't figure out what kind of project it is.
             raise
 

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -2,11 +2,35 @@ import configparser
 from pathlib import Path
 import shutil
 
+import toml
+
 
 def load_setup_cfg():
     setup_cfg = configparser.ConfigParser()
     setup_cfg.read('setup.cfg')
     return setup_cfg
+
+
+def load_pyproject():
+    """
+    Loads the pyproject.toml data.
+
+    Will synthesize data if a legacy setuptools project is detected.
+    """
+    try:
+        return toml.load('pyproject.toml')
+    except FileNotFoundError:
+        if Path('setup.py').exists() or Path('setup.cfg').exists():
+            # Legacy project, use setuptools' legacy backend
+            # (This backend is specified in PEP517)
+            return {
+                'build-system': {
+                    'build-backend': 'setuptools.build_meta:__legacy__',
+                    'requires': ['setuptools>=42'],
+                },
+            }
+        else:
+            raise
 
 
 def find_files(globs):


### PR DESCRIPTION
This will use synthesized `pyproject` data if it detects that it's being run in a legacy project (no `pyproject.toml`, but yes `setup.py` or `setup.cfg`).

Fixes #222