### PR TITLE
CI revamp, add Py3.11 support, drop Py3.7 support, bump dependency versions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,7 +134,9 @@ Windows_task:
       - PYTHON: 3.10.8
       - PYTHON: 3.11.0
   python_install_script:
-    - choco install -y python --version=%PYTHON%
+    # https://docs.python.org/3.6/using/windows.html#installing-without-ui
+    - ps: Invoke-WebRequest -Uri https://www.python.org/ftp/python/${env:PYTHON}/python-${env:PYTHON}-amd64.exe -OutFile C:\python-installer.exe
+    - C:\python-installer.exe /quiet TargetDir=C:\Python SimpleInstall=1
   install_script:
     - C:\Python\python.exe -m pip install -e .[testing]
   version_info_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -131,8 +131,8 @@ Windows_task:
       - PYTHON: 3.7.9
       - PYTHON: 3.8.10
       - PYTHON: 3.9.13
-      - PYTHON: 3.10.8
-      - PYTHON: 3.11.0
+      - PYTHON: 3.10.9
+      - PYTHON: 3.11.1
   python_install_script:
     # https://docs.python.org/3.6/using/windows.html#installing-without-ui
     - ps: Invoke-WebRequest -Uri https://www.python.org/ftp/python/${env:PYTHON}/python-${env:PYTHON}-amd64.exe -OutFile C:\python-installer.exe

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -124,7 +124,6 @@ FreeBSD_task:
     - bork run test
 
 Windows_task:
-  allow_failures: $CIRRUS_TASK_NAME =~ '.*-rc-.*'
   windows_container:
     image: cirrusci/windowsservercore:2019
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ env:
 
 Lint_task:
   container:
-    image: python:3.10-slim
+    image: python:3.11-slim
   install_script:
     - pip install -U --upgrade-strategy eager pip 'setuptools>42'
     - pip install .
@@ -26,6 +26,7 @@ Zipapp_bootstrap_task:
       image: python:3.8-slim
       image: python:3.9-slim
       image: python:3.10-slim
+      image: python:3.11-slim
   setup_script:
     - pip install -U --upgrade-strategy eager pip 'setuptools>42'
     - cp -r . /tmp/bork-pristine
@@ -60,6 +61,7 @@ Linux_task:
       - image: python:3.8-slim
       - image: python:3.9-slim
       - image: python:3.10-slim
+      - image: python:3.11-slim
   install_script:
     - apt-get update
     - apt-get install -y git
@@ -110,6 +112,7 @@ FreeBSD_task:
       - PYTHON: 3.8
       - PYTHON: 3.9
       - PYTHON: 3.10
+      - PYTHON: 3.11
   install_script:
     - PY=`echo $PYTHON | tr -d '.'`
     - pkg install -y python${PY} git
@@ -120,19 +123,29 @@ FreeBSD_task:
     - python${PYTHON} --version
     - bork run test
 
-# Windows_task:
-#   allow_failures: $CIRRUS_TASK_NAME =~ '.*-rc-.*'
-#   windows_container:
-#     os_version: 2019
-#     matrix:
-#       - image: python:3.7-windowsservercore-1809
-#       - image: python:3.8-rc-windowsservercore-1809
-
-#   install_script:
-#     - C:\Python\python.exe -m pip install -e .[testing]
-#   script:
-#     - C:\Python\python.exe --version
-#     - C:\Python\python.exe -m pytest --verbose
+Windows_task:
+  allow_failures: $CIRRUS_TASK_NAME =~ '.*-rc-.*'
+  windows_container:
+    os_version: 2019
+    matrix:
+      - image: python:3.7-windowsservercore-ltsc2022
+      - image: python:3.8-windowsservercore-ltsc2022
+      - image: python:3.9-windowsservercore-ltsc2022
+      - image: python:3.10-windowsservercore-ltsc2022
+      - image: python:3.11-windowsservercore-ltsc2022
+  install_script:
+    - C:\Python\python.exe -m pip install -e .[testing]
+  version_info_script:
+    - C:\Python\python.exe --version
+  # NOTE: The current configuration for `bork lint` doesn't play nice
+  #       with the Windows command prompt, because it doesn't support
+  #       quoted arguments. (E.g. `-k 'pylint or mypy'`)
+  pylint_script:
+    - C:\Python\python.exe -m pytest -k pylint --pylint --verbose
+  mypy_script:
+    - C:\Python\python.exe -m pytest -k mypy --mypy --verbose
+  test_script:
+    - C:\Python\python.exe -m pytest --verbose
 
 success_task:
   name: CI success
@@ -143,7 +156,7 @@ success_task:
     - macOS tests
     - Zipapp bootstraps
     - Lint
-    #- Windows
+    - Windows
 
 # If bork/version.py is modified on the main branch, make a release.
 Release_task:
@@ -154,7 +167,7 @@ Release_task:
     TWINE_PASSWORD: ENCRYPTED[00007524e18bea7b59efea288653efa57b1dbd235ed8af00cc325febfc9076631a2bf58ed330d8fa7ca057adb81579b0]
     BORK_GITHUB_TOKEN: ENCRYPTED[cc80f90b8db1cbe53aabf4f50bf73331c88ea3e1b5412bb0f7bc264bd233f23bf8df4fc2b4c41f87ec07310d63619801]
   container:
-    image: python:3.10-slim
+    image: python:3.11-slim
   install_script:
     - apt-get update
     - apt-get install -y git

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,8 +73,8 @@ Linux_task:
 
 macOS_task:
   alias: macOS tests
-  osx_instance:
-    image: monterey-xcode
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
   env:
     LC_ALL: en_US.UTF-8
     LANG: en_US.UTF-8

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -128,7 +128,6 @@ Windows_task:
     image: cirrusci/windowsservercore:2019
   env:
     matrix:
-      - PYTHON: 3.7.9
       - PYTHON: 3.8.10
       - PYTHON: 3.9.13
       - PYTHON: 3.10.9

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -81,10 +81,10 @@ macOS_task:
     PATH: ${HOME}/.pyenv/shims:${PATH}
     matrix:
       # https://formulae.brew.sh/formula/python@3.10
-      - PYTHON: 3.7.12
-      - PYTHON: 3.8.12
-      - PYTHON: 3.9.8
-      - PYTHON: 3.10.0
+      - PYTHON: 3.8.16
+      - PYTHON: 3.9.16
+      - PYTHON: 3.10.9
+      - PYTHON: 3.11.1
   brew_update_script:
     - brew update
   brew_install_script:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -22,7 +22,6 @@ Zipapp_bootstrap_task:
   alias: Zipapp bootstraps
   container:
     matrix:
-      image: python:3.7-slim
       image: python:3.8-slim
       image: python:3.9-slim
       image: python:3.10-slim
@@ -57,7 +56,6 @@ Linux_task:
   alias: Linux tests
   container:
     matrix:
-      - image: python:3.7-slim
       - image: python:3.8-slim
       - image: python:3.9-slim
       - image: python:3.10-slim
@@ -108,7 +106,6 @@ FreeBSD_task:
     image_family: freebsd-12-2
   env:
     matrix:
-      - PYTHON: 3.7
       - PYTHON: 3.8
       - PYTHON: 3.9
       - PYTHON: 3.10

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,13 +126,16 @@ FreeBSD_task:
 Windows_task:
   allow_failures: $CIRRUS_TASK_NAME =~ '.*-rc-.*'
   windows_container:
-    os_version: 2019
+    image: cirrusci/windowsservercore:2019
+  env:
     matrix:
-      - image: python:3.7-windowsservercore-ltsc2022
-      - image: python:3.8-windowsservercore-ltsc2022
-      - image: python:3.9-windowsservercore-ltsc2022
-      - image: python:3.10-windowsservercore-ltsc2022
-      - image: python:3.11-windowsservercore-ltsc2022
+      - PYTHON: 3.7.9
+      - PYTHON: 3.8.10
+      - PYTHON: 3.9.13
+      - PYTHON: 3.10.8
+      - PYTHON: 3.11.0
+  python_install_script:
+    - choco install -y python --version=%PYTHON%
   install_script:
     - C:\Python\python.exe -m pip install -e .[testing]
   version_info_script:

--- a/.pylintrc
+++ b/.pylintrc
@@ -28,8 +28,9 @@ disable=missing-docstring,
         no-else-return,
         consider-using-f-string,
         consider-iterating-dictionary,
-        consider-using-with, # FIXME: this is worth investigating
-        unspecified-encoding
+        consider-using-with, # FIXME: re-enabling this is worth investigating
+        unspecified-encoding,
+        unnecessary-lambda-assignment # FIXME: also worth investigating
 
 
 [REPORTS]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.11-slim
 
 ARG VERSION
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ A frontend for building and releasing [PEP 517](https://www.python.org/dev/peps/
 Includes a basic task runner, in the form of `bork run <task name>`. Tasks
 are defined in your `pyproject.toml` file.
 
-Bork requires Python 3.7 or newer.
+Bork requires Python 3.7 or newer; 3.8 or newer is recommended.
+(3.7 is expected to reach End Of Life in June 2023.)
 
 [build-status-img]: https://api.cirrus-ci.com/github/duckinator/bork.svg
 [build-status-link]: https://cirrus-ci.com/github/duckinator/bork

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ A frontend for building and releasing [PEP 517](https://www.python.org/dev/peps/
 Includes a basic task runner, in the form of `bork run <task name>`. Tasks
 are defined in your `pyproject.toml` file.
 
-Bork requires Python 3.7 or newer; 3.8 or newer is recommended.
-(3.7 is expected to reach End Of Life in June 2023.)
+Bork requires Python 3.8 or newer.
 
 [build-status-img]: https://api.cirrus-ci.com/github/duckinator/bork.svg
 [build-status-link]: https://cirrus-ci.com/github/duckinator/bork

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -88,8 +88,8 @@ def run(alias):
 
 
 def main():
-    if sys.version_info < (3, 7):
-        print('ERROR: Bork requires Python 3.7 or newer', file=sys.stderr)
+    if sys.version_info < (3, 8):
+        print('ERROR: Bork requires Python 3.8 or newer', file=sys.stderr)
 
     verbose = '--verbose' in sys.argv
     if verbose:

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,14 +27,14 @@ python_requires = >=3.7
 # The importlib_metadata library is required by Twine for Python 3.7 and
 # earlier, but we pull it in unconditionally so the zipapp is version-agnostic.
 install_requires =
-    wheel~=0.36.2
-    build~=0.1.0
-    pep517~=0.10.0
-    packaging~=20.9
+    wheel~=0.38.4
+    build~=0.9.0
+    pep517~=0.13.0
+    packaging~=21.3
     toml~=0.10.2
-    twine~=3.4.1
-    click~=7.1.2
-    coloredlogs~=15.0.0
+    twine~=4.0.1
+    click~=8.1.3
+    coloredlogs~=15.0.1
     # importlib_metadata can be removed after Python 3.7 support is dropped.
     importlib_metadata
 
@@ -43,13 +43,13 @@ tests_require =
 
 [options.extras_require]
 testing_only =
-    pytest==6.2.5
+    pytest==7.2.0
 
 testing =
-    pylint==2.12.2
-    pytest==6.2.5
-    pytest-pylint==0.18.0
-    pytest-mypy==0.8.1
+    pylint==2.15.5
+    pytest==7.2.0
+    pytest-pylint==0.19.0
+    pytest-mypy==0.10.1
 
 [options.entry_points]
 console_scripts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,6 @@ url = https://github.com/duckinator/bork
 license = MIT
 classifiers =
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -21,13 +20,10 @@ classifiers =
 [options]
 include_package_data = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 
 # The packaging library is used by bork.github_api, and also pulled in via
 # twine -> readme_renderer -> bleach -> packaging.
-#
-# The importlib_metadata library is required by Twine for Python 3.7 and
-# earlier, but we pull it in unconditionally so the zipapp is version-agnostic.
 install_requires =
     wheel~=0.38.4
     build~=0.9.0
@@ -37,8 +33,6 @@ install_requires =
     twine~=4.0.1
     click~=8.1.3
     coloredlogs~=15.0.1
-    # importlib_metadata can be removed after Python 3.7 support is dropped.
-    importlib_metadata
 
 tests_require =
     bork[testing]


### PR DESCRIPTION
- Re-enable Windows CI
- Add Python 3.11 to CI matrix
- Remove Python 3.7 support
- Switch macOS CI from Intel hardware to Apple Silicon hardware
  - (Cirrus CI is dropping macOS Intel hardware support on January 1st 2023.)
- Bump dependency versions