### PR TITLE
Fix `bork dependencies`/`bork.api.dependencies()`

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -4,7 +4,7 @@ from signal import Signals
 import subprocess
 import sys
 
-import pep517  # type:ignore
+import pep517.meta  # type:ignore
 
 from . import builder
 from . import github


### PR DESCRIPTION
Import `pep517.meta` since that's the part of pep517 that `bork dependencies`/`bork.api.dependencies()` uses.