### PR TITLE
Remove `setup.py`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,0 @@
-from setuptools import setup  # type: ignore
-
-setup()


### PR DESCRIPTION
Editable installs don't need it anymore.