### PR TITLE
BREAKING CHANGE: Remove `bork dependencies`; update deps

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -4,8 +4,6 @@ from signal import Signals
 import subprocess
 import sys
 
-import pep517.meta  # type:ignore
-
 from . import builder
 from . import github
 from . import pypi
@@ -68,11 +66,6 @@ def clean():
     for name in Path.cwd().glob('*.egg-info'):
         if name.is_dir():
             try_delete(name)
-
-
-def dependencies():
-    """Returns the list of dependencies for the project."""
-    return pep517.meta.load('.').metadata.get_all('Requires-Dist')
 
 
 def download(package, release_tag, file_pattern, directory):

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -72,19 +72,6 @@ def clean():
 
 
 @cli.command()
-@click.option('-o', '--output', type=click.File('w'), default='-',
-              help='File in which to save the list of dependencies.')
-def dependencies(output):
-    """
-    ### `bork dependencies`
-
-    List dependencies of the project.
-    """
-    for dep in api.dependencies():
-        print(dep, file=output)
-
-
-@cli.command()
 @click.option('--files', default='*.pyz',
               help='Comma-separated list of filenames to download. Supports '
                    'wildcards (* = everything, ? = any single character).')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ classifiers = [
 # The packaging library is used by bork.github_api, and also pulled in via
 # twine -> readme_renderer -> bleach -> packaging.
 dependencies = [
-    "wheel~=0.38.4",
-    "build~=0.9.0",
+    "wheel~=0.41.2",
+    "build~=1.0.3",
     "pep517~=0.13.0",
     "packaging~=21.3",
     "toml~=0.10.2",
-    "twine~=4.0.1",
+    "twine==4.0.1", # 4.0.2 starts pulling in Rust.
     "click~=8.1.3",
     "coloredlogs~=15.0.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 dependencies = [
     "wheel~=0.41.2",
     "build~=1.0.3",
-    "pep517~=0.13.0",
     "packaging~=21.3",
     "toml~=0.10.2",
     "twine==4.0.1", # 4.0.2 starts pulling in Rust.


### PR DESCRIPTION
`bork dependencies` was using the now-unmaintained pep517 library.

As best I can tell, `pep517` was split into `pyproject-hooks` and `build`, but
neither has this functionality. Given that it's not super important, I
opted to remove it instead of having an unmaintained dependency.