### PR TITLE
[v7.0.2] Fix `bork build` failure due to bad mkdir() call.

### DIFF
--- a/bork/builder.py
+++ b/bork/builder.py
@@ -51,7 +51,7 @@ def _bdist_file():
 def _prepare_zipapp(dest, bdist_file):
     # Prepare zipapp directory.
     try_delete(dest)
-    Path(dest).mkdir()
+    Path(dest).mkdir(parents=True)
     return subprocess.check_call([
         sys.executable, '-m', 'pip', 'install', '--target', dest, bdist_file
     ])

--- a/bork/version.py
+++ b/bork/version.py
@@ -1,4 +1,4 @@
 # This file should only ever be modified to change the version.
 # This will automatically prepare and create a release.
 
-__version__ = '7.0.1'
+__version__ = '7.0.2'


### PR DESCRIPTION
This is the only user-facing change for v7.0.2.

Fixes #338.