### PR TITLE
Update Python versions in CI and Dockerfile

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,6 +1,6 @@
 Lint_task:
   container:
-    image: python:3.11-slim
+    image: python:3.12-slim
   install_script:
     - pip install -U --upgrade-strategy eager pip 'setuptools>61'
     - pip install .

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,10 +73,10 @@ macOS_task:
     PATH: ${HOME}/.pyenv/shims:${PATH}
     matrix:
       # https://formulae.brew.sh/formula/python@3.10
-      - PYTHON: 3.8.16
-      - PYTHON: 3.9.16
-      - PYTHON: 3.10.9
-      - PYTHON: 3.11.1
+      - PYTHON: 3.8.18
+      - PYTHON: 3.9.18
+      - PYTHON: 3.10.13
+      - PYTHON: 3.11.6
       - PYTHON: 3.12.0
   brew_update_script:
     - brew update

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -134,8 +134,8 @@ Windows_task:
     matrix:
       - PYTHON: 3.8.10
       - PYTHON: 3.9.13
-      - PYTHON: 3.10.9
-      - PYTHON: 3.11.1
+      - PYTHON: 3.10.11
+      - PYTHON: 3.11.6
       - PYTHON: 3.12.0
   python_install_script:
     # https://docs.python.org/3.6/using/windows.html#installing-without-ui

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,6 +18,7 @@ Zipapp_bootstrap_task:
       image: python:3.9-slim
       image: python:3.10-slim
       image: python:3.11-slim
+      image: python:3.12-slim
   setup_script:
     - pip install -U --upgrade-strategy eager pip 'setuptools>61'
     - cp -r . /tmp/bork-pristine
@@ -52,6 +53,7 @@ Linux_task:
       - image: python:3.9-slim
       - image: python:3.10-slim
       - image: python:3.11-slim
+      - image: python:3.12-slim
   install_script:
     - apt-get update
     - apt-get install -y git
@@ -75,6 +77,7 @@ macOS_task:
       - PYTHON: 3.9.16
       - PYTHON: 3.10.9
       - PYTHON: 3.11.1
+      - PYTHON: 3.12.0
   brew_update_script:
     - brew update
   brew_install_script:
@@ -107,6 +110,7 @@ FreeBSD_task:
       - PYTHON: 3.9
       - PYTHON: 3.10
       - PYTHON: 3.11
+      # TODO: PYTHON: 3.12
   install_script:
     - PY=`echo $PYTHON | tr -d '.'`
     - pkg install -y python${PY} git
@@ -132,6 +136,7 @@ Windows_task:
       - PYTHON: 3.9.13
       - PYTHON: 3.10.9
       - PYTHON: 3.11.1
+      - PYTHON: 3.12.0
   python_install_script:
     # https://docs.python.org/3.6/using/windows.html#installing-without-ui
     - ps: Invoke-WebRequest -Uri https://www.python.org/ftp/python/${env:PYTHON}/python-${env:PYTHON}-amd64.exe -OutFile C:\python-installer.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 ARG VERSION
 


### PR DESCRIPTION
- Bump default py version (in Dockerfile and lint task) to 3.12
- CI: Run tests under Py 3.12
- CI: Update Python versions in macOS environment
- CI: Update Python versions in Windows environment
