### PR TITLE
load_pyproject: Prefer the stdlib's TOML parser when available

### DIFF
--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 import shutil
 
-import toml  # type: ignore
+try:
+    import tomllib
+except ImportError:
+    import toml as tomllib  # type: ignore
 
 
 def load_pyproject():
@@ -11,7 +14,9 @@ def load_pyproject():
     Will synthesize data if a legacy setuptools project is detected.
     """
     try:
-        return toml.load('pyproject.toml')
+        pyproject = Path.cwd() / 'pyproject.toml'
+        return tomllib.loads(pyproject.read_text())  # Mildly inefficient, but portable
+
     except FileNotFoundError:
         if Path('setup.py').exists() or Path('setup.cfg').exists():
             # Legacy project, use setuptools' legacy backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "wheel~=0.41.2",
     "build~=1.0.3",
     "packaging~=21.3",
-    "toml~=0.10.2",
+    "toml~=0.10.2; python_version < '3.11'",
     "twine==4.0.1",
     "coloredlogs~=15.0.1",
     # pip is used by bork.builder._prepare_zipapp(),


### PR DESCRIPTION
Upstream development of the `toml` package seem to have mostly stalled back in 2020.

Moreover, I'm not aware of any reason to prefer it over the stdlib's parser (introduced in Python 3.11) and that's one less dependency to care about.  =^.^'=
