### PR TITLE
Deprecate `download` command & function

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from signal import Signals
 import subprocess
 import sys
+from warnings import warn
 
 from . import builder
 from .filesystem import try_delete, load_pyproject
@@ -67,6 +68,12 @@ def download(package, release_tag, file_pattern, directory):
             This directory is created, if needed.
     """
     from homf.api import github, pypi  # type: ignore
+
+    warn(
+        "`bork.api.download` has been split out into Homf",
+        DeprecationWarning,
+        stacklevel = 2,
+    )
 
     if file_pattern is None or len(file_pattern) == 0:
         raise ValueError('file_pattern must be non-empty.')

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -232,15 +232,8 @@ def main(cmd_args=None):
         import coloredlogs  # type: ignore
         # pylint: enable=import-outside-toplevel
 
-        # Default to only printing INFO and higher severity messages.
-        log_level = logging.INFO
-
-        # If we got '--verbose' or '--debug', print DEBUG and higher severity messages.
-        if args.verbose:
-            log_level = logging.DEBUG
-
         coloredlogs.install(
-            level=log_level,
+            level=logging.DEBUG if args.verbose else logging.INFO,
             fmt='%(name)s %(levelname)s %(message)s',
         )
 

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -216,6 +216,8 @@ def main(cmd_args=None):
     if sys.version_info < (3, 10):
         print('ERROR: Bork requires Python 3.10 or newer', file=sys.stderr)
 
+    logging.captureWarnings(True)
+
     cmd_args = cmd_args or sys.argv[1:]
     if len(cmd_args) == 0:
         cmd_args = ["--help"]

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -93,6 +93,10 @@ def download(args):
     package = args.PACKAGE
     release_tag = args.RELEASE
 
+    if not sys.flags.dev_mode:
+        # Avoid a double-warning if the API's deprecation was shown
+        logging.warning("`bork download` is deprecated; its functionality has been split out into Homf")
+
     api.download(package, release_tag, files, directory)
 
 


### PR DESCRIPTION
- [x] `{api, cli}.download`: add deprecation warning
- [x] `cli.main`: capture Python warnings into the `logging` pipeline
  not technically needed, since `cli.download` calls `logging.warning`, but generally useful
- [x] `cli.main`: minor refactoring

Closes #357