### PR TITLE
pyproject: update dependencies

### DIFF
--- a/bork/builder.py
+++ b/bork/builder.py
@@ -2,6 +2,7 @@ from .filesystem import load_pyproject, try_delete
 from .log import logger
 import build
 import contextlib
+import importlib
 from pathlib import Path
 import subprocess
 import sys
@@ -9,11 +10,6 @@ import tempfile
 # Slight kludge so we can have a function named zipapp().
 import zipapp as Zipapp  # noqa: N812
 
-# When Python 3.8 and 3.9 support is dropped, drop the importlib_metadata backport.
-if sys.version_info[:2] >= (3, 10):
-    from importlib import metadata as importlib_metadata
-else:
-    import importlib_metadata
 
 class NeedsBuildError(Exception):
     pass
@@ -68,7 +64,7 @@ def metadata():
     with prepared_environment(srcdir, outdir) as (env, builder):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(builder.metadata_path(tmpdir))
-            return importlib_metadata.Distribution.at(path).metadata
+            return importlib.metadata.Distribution.at(path).metadata
 
 def _python_interpreter(config):
     # To override the default interpreter, add this to your project's pyproject.toml:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,11 @@ documentation = "https://bork.readthedocs.io/en/latest/"
 [project.optional-dependencies]
 lint = [
     "ruff",
-    "mypy==1.5.1",
+    "mypy==1.11.1",
 ]
 
 test = [
-    "pytest==7.4.2",
+    "pytest==8.3.2",
 
     # build-system.requires for packages built during tests, including bork itself
     "setuptools >= 61", "wheel"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,16 +21,16 @@ classifiers = [
 ]
 
 dependencies = [
-    "build~=1.2",
-    "coloredlogs~=15.0",
-    "homf~=1.1", # `bork download` stubs out to it
-    "packaging~=23.2", # The packaging library is used by bork.github_api.
+    "build ~= 1.2",
+    "coloredlogs ~= 15.0",
+    "homf ~= 1.1", # `bork download` stubs out to it
+    "packaging ~= 23.2", # The packaging library is used by bork.github_api.
     "pip", # used by bork.builder._prepare_zipapp
-    "urllib3~=2.2",
+    "urllib3 ~= 2.2",
 
     # Compatibility shims for older Python versions
     "importlib_metadata; python_version < '3.10'",
-    "toml~=0.10.2; python_version < '3.11'",
+    "toml ~= 0.10.2; python_version < '3.11'",
 ]
 
 requires-python = ">= 3.10"
@@ -42,11 +42,11 @@ documentation = "https://bork.readthedocs.io/en/latest/"
 [project.optional-dependencies]
 lint = [
     "ruff",
-    "mypy==1.11.1",
+    "mypy == 1.11.1",
 ]
 
 test = [
-    "pytest==8.3.2",
+    "pytest == 8.3.2",
 
     # build-system.requires for packages built during tests, including bork itself
     "setuptools >= 61", "wheel",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "urllib3 ~= 2.2",
 
     # Compatibility shims for older Python versions
-    "importlib_metadata; python_version < '3.10'",
     "toml ~= 0.10.2; python_version < '3.11'",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ classifiers = [
 ]
 
 dependencies = [
-    "build~=1.2.1",
-    "coloredlogs~=15.0.1",
+    "build~=1.2",
+    "coloredlogs~=15.0",
     "homf~=1.1", # `bork download` stubs out to it
     "packaging~=23.2", # The packaging library is used by bork.github_api.
     "pip", # used by bork.builder._prepare_zipapp
-    "urllib3~=2.2.2",
+    "urllib3~=2.2",
 
     # Compatibility shims for older Python versions
     "importlib_metadata; python_version < '3.10'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pytest==8.3.2",
 
     # build-system.requires for packages built during tests, including bork itself
-    "setuptools >= 61", "wheel"
+    "setuptools >= 61", "wheel",
 ]
 
 docs = [


### PR DESCRIPTION
- [x] loosen dependencies' version constraints
  For instance, `build ~= 1.2.1` won't accept `1.3.*` versions, which should be API-compatible (assuming SemVer)
- [x] update `lint` and `test` dependencies
  I maintained the pinning of exact versions for dev tools, though I think we could loosen that for `pytest`
- [x] uniformize the use of a trailing comma
- [x] uniformize version constraints formatting
