### PR TITLE
api.download: fix `package` parsing bug

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -74,7 +74,7 @@ def download(package, release_tag, file_pattern, directory):
     if ':' not in package:
         raise ValueError('Invalid package/repository -- no source given.')
 
-    source, package = package.split(':')
+    source, package = package.split(':', 1)
 
     match source:
         case 'github' | 'gh':


### PR DESCRIPTION
Granted, IDK whether the name of PyPI packages, GitHub users, or repos can contain `:` at all.

Still, this shouldn't happen:
```
❯ python -m bork --verbose download gh:duckinator/emanate:aaa v7.0.0
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/nicoo/dev/py/puppy/bork/bork/__main__.py", line 3, in <module>
    cli.main()
  File "/home/nicoo/dev/py/puppy/bork/bork/cli.py", line 248, in main
    args.func(args)
  File "/home/nicoo/dev/py/puppy/bork/bork/cli.py", line 96, in download
    api.download(package, release_tag, files, directory)
  File "/home/nicoo/dev/py/puppy/bork/bork/api.py", line 77, in download
    source, package = package.split(':')
    ^^^^^^^^^^^^^^^
ValueError: too many values to unpack (expected 2)
```
