### PR TITLE
builder: refactor, remove implicit global state

### DIFF
--- a/bork/api.py
+++ b/bork/api.py
@@ -19,11 +19,16 @@ def aliases():
 
 def build():
     """Build the project."""
-    builder.dist()
+    with builder.prepare(src = Path.cwd(), dst = Path.cwd() / 'dist') as b:
+        b.build("sdist")
+        b.build("wheel")
+
 
 def build_zipapp(zipapp_main=None):
     """Build the project as a ZipApp."""
-    builder.zipapp(zipapp_main)
+    # TODO: change the API so the same `Builder` can be reused
+    with builder.prepare(src = Path.cwd(), dst = Path.cwd() / 'dist') as b:
+        b.zipapp(zipapp_main)
 
 
 def clean():

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -1,126 +1,122 @@
-from .filesystem import load_pyproject, try_delete
+from .filesystem import load_pyproject
 from .log import logger
+
 import build
-import contextlib
-import importlib
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
-import subprocess
-import sys
-import tempfile
-# Slight kludge so we can have a function named zipapp().
-import zipapp as Zipapp  # noqa: N812
+from tempfile import TemporaryDirectory
+from typing import Literal, Mapping
+import importlib, importlib.metadata
+import subprocess, sys, zipapp
 
 
 class NeedsBuildError(Exception):
     pass
 
-
 # The "proper" way to handle the default would be to check python_requires
 # in pyproject.toml. But, since Bork needs Python 3, there's no point.
 DEFAULT_PYTHON_INTERPRETER = '/usr/bin/env python3'
 
-@contextlib.contextmanager
-def prepared_environment(srcdir, outdir):
-    """Usage:
-        with prepared_environment(".", "./dist") as (env, builder):
-            # ...
-    """
+
+Distribution = Literal["sdist", "wheel"]
+BuildSettings = Mapping[str, str | Sequence[str]]
+
+class Builder(ABC):
+    @abstractmethod
+    def metadata(self) -> importlib.metadata.PackageMetadata: ...
+
+    @abstractmethod
+    def build(self, dist: Distribution, *, settings: BuildSettings = {}) -> Path: ...
+
+    @abstractmethod
+    def zipapp(self, main: str | None) -> Path: ...
+
+
+@contextmanager
+def prepare(src: Path, dst: Path) -> Iterator[Builder]:
+    @dataclass(frozen = True)
+    class Bob(Builder):
+        src: Path
+        dst: Path
+        env: build.env.IsolatedEnv
+        bld: build.ProjectBuilder
+
+        def metadata_path(self) -> Path:
+            logger().info("Building wheel metadata")
+
+            out_dir = Path(env.path) / 'metadata'
+            out_dir.mkdir(exist_ok = True)
+            return Path(self.bld.metadata_path(out_dir))
+
+        def metadata(self) -> importlib.metadata.PackageMetadata:
+            return importlib.metadata.PathDistribution(
+                self.metadata_path()
+            ).metadata
+
+        def build(self, dist, *, settings = {}):
+            logger().info(f"Building {dist}")
+            self.env.install(
+                self.bld.get_requires_for_build(dist, settings)
+            )
+            # TODO: reuse metadata_path if it was already built
+            return Path( self.bld.build(dist, self.dst, settings) )
+
+        def zipapp(self, main):
+            log = logger()
+            log.info("Building zipapp")
+
+            log.debug("Loading configuration")
+            config = load_pyproject().get("tool", {}).get("bork", {})
+            zipapp_cfg = config.get("zipapp")
+
+            log.debug("Loading metadata")
+            meta = self.metadata()
+            dst = self.dst / f"{meta['name']}-{meta['version']}.pyz"
+
+            with TemporaryDirectory() as tmp:
+                # Install the wheel we just built, including all dependencies
+                wheel = self.build("wheel")
+
+                log.info(f"Installing '{wheel}'")
+                subprocess.check_call((
+                    sys.executable, '-m', 'pip', 'install',
+                    '--target', tmp,
+                    wheel
+                ))
+
+                log.info(f"Creating zipapp archive '{dst}'")
+                zipapp.create_archive(
+                    source = tmp,
+                    target = dst,
+                    interpreter = config.get('python_interpreter', DEFAULT_PYTHON_INTERPRETER),
+                    main = main or zipapp_cfg['main'],  # TODO: give a more user-friendly error if neither is set
+                    compressed = True,
+                )
+
+            if not dst.exists():
+                raise RuntimeError(f"Failed to build zipapp: {dst}")
+
+            log.info(f"Zipapp '{dst}' successfully built")
+            return dst
+
+
+    src, dst = src.resolve(), dst.resolve()
+
     with build.env.DefaultIsolatedEnv() as env:
-        builder = build.ProjectBuilder.from_isolated_env(env, srcdir)
-        # Install deps from `project.build_system_requires`
-        env.install(builder.build_system_requires)
-        # Yield env and builder.
-        yield (env, builder)
-
-def dist(backend_settings=None):
-    """Build the sdist and wheel distributions.
-
-    :param backend_settings: Passed as ``config_settings`` to
-        ``build.ProjectBuilder.get_requires_for_build(distribution, config_settings)`` and
-        ``build.ProjectBuilder.build(distribution, outdir, config_settings)
-    """
-
-    srcdir = "."
-    outdir = "./dist"
-
-    with build.env.DefaultIsolatedEnv() as env:
-        builder = build.ProjectBuilder.from_isolated_env(env, srcdir)
-        # Install deps from `project.build_system_requires`
+        builder = build.ProjectBuilder.from_isolated_env(env, src)
         env.install(builder.build_system_requires)
 
-        results = {}
-        for distribution in ["sdist", "wheel"]:
-            # Install deps that are required to build the distribution.
-            env.install(builder.get_requires_for_build(distribution, backend_settings or {}))
-
-            results[distribution] = builder.build(distribution, outdir, backend_settings or {})
-        return results
+        yield Bob(src, dst, env, builder)
 
 
-def metadata():
-    srcdir = "."
-    outdir = "./dist"
-
-    with prepared_environment(srcdir, outdir) as (env, builder):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            path = Path(builder.metadata_path(tmpdir))
-            return importlib.metadata.Distribution.at(path).metadata
-
-def _python_interpreter(config):
-    # To override the default interpreter, add this to your project's pyproject.toml:
-    #
-    # [bork]
-    # python_interpreter = /path/to/python
-    return config.get('python_interpreter', DEFAULT_PYTHON_INTERPRETER)
-
-
-def _bdist_file():
+# TODO: remove last caller (api.release)
+def version_from_bdist_file():
     files = list(Path.cwd().glob('dist/*.whl'))
     if not files:
         raise NeedsBuildError
-    return max(files)
 
-
-def _prepare_zipapp(dest, bdist_file):
-    # Prepare zipapp directory.
-    try_delete(dest)
-    Path(dest).mkdir(parents=True)
-    return subprocess.check_call([
-        sys.executable, '-m', 'pip', 'install', '--target', dest, bdist_file
-    ])
-
-
-def version_from_bdist_file():
-    return _bdist_file().name.replace('.tar.gz', '').split('-')[1]
-
-
-def zipapp(zipapp_main):
-    """
-    Build a zipapp for the project.
-
-    dist() should be called before zipapp().
-    """
-
-    log = logger()
-
-    log.info("Building ZipApp.")
-
-    pyproject = load_pyproject()
-    config = pyproject.get('tool', {}).get('bork', {})
-    zipapp_cfg = config.get('zipapp', {})
-
-    name = metadata()['name']
-    dest = str(Path('build', 'zipapp'))
-    version = version_from_bdist_file()
-    main = zipapp_main or zipapp_cfg['main']
-
-    # Output file is dist/<package name>-<package version>.pyz.
-    target = f"dist/{name}-{version}.pyz"
-
-    _prepare_zipapp(dest, _bdist_file())
-
-    Zipapp.create_archive(dest, target, _python_interpreter(config), main,
-        compressed=True)
-    if not Path(target).exists():
-        raise RuntimeError(f"Failed to build zipapp: {target}")
-    log.info("Finished building ZipApp.")
+    return max(files).name.replace('.tar.gz', '').split('-')[1]

--- a/bork/pypi.py
+++ b/bork/pypi.py
@@ -102,14 +102,17 @@ class Uploader:
         response = post(url, form, auth=(self.username, self.password))
         return response
 
-    def upload(self, dry_run=True):
+    def upload(self, *, dry_run = True, metadata = None):
         log = logger()
 
         msg_prefix = "Uploading"
         if dry_run:
             msg_prefix = "Pretending to upload"
 
-        metadata = builder.metadata().json
+        if metadata is None:
+            # Pure sadness, more hardcoded paths and another rebuild  >_>'
+            with builder.prepare(Path.cwd(), Path("dist")) as b:
+                metadata = b.metadata()
 
         log.info("%s %i files to PyPi repository '%s'.", msg_prefix, len(self.files),
                 self.repository)
@@ -127,6 +130,6 @@ class Uploader:
                 log.info(response.data.decode().strip())
 
 
-def upload(repository_name, *globs, dry_run=False):
+def upload(repository_name, *globs, **kwargs):
     files = find_files(globs)
-    Uploader(files, repository_name).upload(dry_run)
+    Uploader(files, repository_name).upload(**kwargs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,3 +93,8 @@ test-slow = "pytest --verbose -m slow"
 docs = "sphinx-build -b html -d build/doctrees docs/source/ docs/build/"
 docs-clean = "rm -rf docs/build/"
 #sphinx-apidoc = "sphinx-apidoc -o ./docs/source ./bork"
+
+[tool.ruff.lint]
+ignore = [
+    "E401",  # multiple imports per line
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,7 @@ def _src_name(src):
 test_dir = Path(__file__).parent
 
 @pytest.fixture(scope="session", ids=_src_name, params=(
-    Path(__file__).parent / 'fixtures' / 'minimal-package',
+    test_dir / 'fixtures' / 'minimal-package',
     test_dir / 'fixtures' / 'poetry-package',
     test_dir / 'fixtures' / 'hatch-package',
     Path(__file__).parent.parent,  # bork's source tree

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,26 +1,17 @@
-import shutil
-import sys
 from pathlib import Path
+import shutil
 
 import pytest
 
 from helpers import chdir, check_run
 
 
-if sys.version_info >= (3, 9):
-    removesuffix = str.removesuffix
-else:
-    def removesuffix(s: str, suffix: str) -> str:
-        if not s.endswith(suffix):
-            return s
-        return s[:-len(suffix)]
-
-
 def _src_name(src):
     if isinstance(src, Path):
         return src.name
 
-    return removesuffix(src, '.git').rsplit('/', 1)[1]
+    _, name = src.rsplit("/", 1)
+    return name.removesuffix(".git")
 
 
 # pylint: disable=redefined-outer-name

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,55 @@
+from functools import partial
+from pathlib import Path
+from typing import Literal
+import logging
+
+import pytest
+
+from bork import builder
+from utils import cd
+
+
+def is_beneath(child: Path, parent: Path) -> Path | Literal[False]:
+    try:
+        return child.relative_to(parent)
+    except ValueError:
+        return False
+
+def _artefact(dst, artefact, suffix = ""):
+    assert isinstance(artefact, Path)
+    assert artefact.name.endswith(suffix)
+
+    match is_beneath(artefact, dst):
+        case False:
+            raise ValueError(f"'{artefact}' not in directory '{dst}'")
+        case rel if len(rel.parts) == 1:
+            return
+        case rel:
+            raise ValueError(f"'{rel}' is not directly in directory")
+
+
+@pytest.mark.slow
+def test_builder_cwd(project_src, tmp_path):
+    "Ensure that `builder` does not depend on the current working directory"
+    log = logging.getLogger(__name__ + ".test_builder_cwd")
+    dst = (tmp_path / 'dist').resolve()
+    artefact = partial(_artefact, dst)
+
+    with cd(tmp_path):
+      log.info(f"Preparing builder from {Path.cwd()}")
+      with builder.prepare(project_src, dst.relative_to(Path.cwd())) as b:
+          with cd(tmp_path / "metadata", mkdir = True):
+              log.info(f"Building metadata from {Path.cwd()}")
+              meta = b.metadata()
+
+              # Can't actually check the object implements the protocol
+              for k in ("name", "version", "Metadata-Version"):
+                  assert k in meta, f"built metadata does not contain '{k}'"
+
+          with cd(tmp_path / "sdist", mkdir = True):
+              log.info(f"Building source distribution from {Path.cwd()}")
+              artefact(b.build("sdist"), ".tar.gz")
+
+          with cd(tmp_path / "wheel", mkdir = True):
+              log.info(f"Building wheel from {Path.cwd()}")
+              artefact(b.build("wheel"), ".whl")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+from pathlib import Path
+import os
+
+@contextmanager
+def cd(d: Path, *, mkdir: bool = False):
+    # TODO(nicoo) get that check working
+    # if not d.is_dir() or (mkdir and not d.exists()):
+    #     raise ValueError(f"cd: '{d}' is not a directory")
+
+    prev_wd = Path.cwd()
+    if mkdir:
+        d.mkdir(exist_ok = True)
+
+    try:
+        os.chdir(d)
+        yield
+    finally:
+        os.chdir(prev_wd)


### PR DESCRIPTION
- [x] Restructure `builder`'s API, reducing it to
  - a `prepare(src: Path, dst: Path) -> Builder` context manager
   which sets up an isolated environment and installs the build system's dependencies
  - a `Builder` abstract class exposing `build`, `metadata`, and `zipapp` methods

  `Builder` is made abstract, so instances can only be obtained within the managed context, ensuring the build environment was not cleaned up between calls.  (Unless one uses RTTI to get the concrete class from a `prepare`d object, or does not use `prepare` as a context manager...)

- Add tests for `builder` ensuring there are no dependencies left on
  - [x] method-call order, nor
  - global state, including:
    - [x] current working directory
    - [ ] filesystem state (outside of the `IsolatedEnv` itself, which is a fresh directory beneath `/tmp` and source dir)
      in particular the contents of the destination directory should not matter

- [ ] Fix suboptimal use of the builder API, due to API limitations in the rest of bork
  - `api.build` and `api.build_zipapp` do not reuse the same `Builder`, causing isolated environment and wheel to be built twice ;
  - `api.release` does not have access to the `Builder`'s returned artefact `Path`s and `PackageMetadata`, instead performing filesystem-[augury]
  - `pypi.Uploader.upload` isn't passed the metadata, and would have to rebuild it again... with no guarantee that the source wasn't modified between `bork build` and `bork release` :imp:
    That issue already existed, so I won't consider it a blocker for this PR.

  I think I can safely say this will be addressed in follow-up PRs, given that we'll likely end up rewriting Bork's entire API surface, both internal and public.

[augury]: https://en.wikipedia.org/wiki/Augury

PS: I just realised I could just squash all those commits together, given that I did a few minor refactors... then rewrote the entire hecking file  >_>'