### PR TITLE
Use a common configuration model

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,8 +15,7 @@ Lint_task:
     - mypy --version
     - bork run lint
 
-Zipapp_bootstrap_task:
-  alias: Zipapp bootstraps
+Linux_task:
   persistent_worker: &linuxes
     isolation:
       container:
@@ -27,34 +26,6 @@ Zipapp_bootstrap_task:
           - image: python:3.11-slim
           - image: python:3.12-slim
           - image: python:3.13-rc-slim
-  setup_script:
-    - pip install -U --upgrade-strategy eager pip 'setuptools>61'
-    - cp -r . /tmp/bork-pristine
-    - cp -r /tmp/bork-pristine /tmp/pass1
-    - cp -r /tmp/bork-pristine /tmp/pass2
-    - cp -r /tmp/bork-pristine /tmp/pass3
-  # Make sure Bork can build itself.
-  pass_1_script:
-    - cd /tmp/pass1
-    - python3 --version
-    - pip install . .[test]
-    - bork build
-  # Make sure the Bork zipapp from Pass 1 can build Bork.
-  pass_2_script:
-    - cd /tmp/pass2
-    - cp /tmp/pass1/dist/bork-*.pyz /tmp/bork-pass1.pyz
-    - python3 /tmp/bork-pass1.pyz build
-  # Make sure the Bork zipapp built from Pass 2 can build Bork.
-  # ime with other self-building software, this is prone to blowing up.
-  pass_3_script:
-    - cd /tmp/pass3
-    - cp /tmp/pass2/dist/bork-*.pyz /tmp/bork-pass2.pyz
-    - python3 /tmp/bork-pass2.pyz build
-    - '[ -e ./dist/bork-*.pyz ]'
-
-
-Linux_task:
-  persistent_worker: *linuxes
   install_script:
     - apt-get update
     - apt-get install -y git
@@ -167,7 +138,6 @@ success_task:
     - Linux quick
     - Linux slow
     - macOS tests
-    - Zipapp bootstraps
     - Lint
     - Windows
 

--- a/bork/api.py
+++ b/bork/api.py
@@ -13,7 +13,7 @@ from .log import logger
 
 
 def aliases():
-    """Returns a list of the aliases defined in pyproject.toml."""
+    """Returns the aliases defined in pyproject.toml."""
     return Config.from_project(Path.cwd()).bork.aliases
 
 
@@ -168,15 +168,9 @@ def release(repository_name, dry_run, github_release_override=None, pypi_release
 
 def run(alias):
     """Run the alias specified by `alias`, as defined in pyproject.toml."""
-    match aliases().get(alias):
-        case None:
-            raise RuntimeError(f"No such alias: '{alias}'")
-        case [*cmds]:
-            commands = cmds
-        case cmd if isinstance(cmd, str):
-            commands = (cmd, )
-        case x:
-            raise TypeError(f"commands must be (a sequence of) str, was {type(x)}")
+    commands = aliases().get(alias)
+    if commands is None:
+        raise RuntimeError(f"No such alias: '{alias}'")
 
     logger().info("Running '%s'", commands)
     try:

--- a/bork/api.py
+++ b/bork/api.py
@@ -1,5 +1,4 @@
 from functools import partial
-import os
 from pathlib import Path
 from signal import Signals
 import subprocess
@@ -7,14 +6,15 @@ import sys
 from warnings import warn
 
 from . import builder
-from .filesystem import try_delete, load_pyproject
+from .config import Config
+from .creds import Credentials
+from .filesystem import try_delete
 from .log import logger
 
 
 def aliases():
     """Returns a list of the aliases defined in pyproject.toml."""
-    pyproject = load_pyproject()
-    return pyproject.get('tool', {}).get('bork', {}).get('aliases', {})
+    return Config.from_project(Path.cwd()).bork.aliases
 
 
 def build():
@@ -121,36 +121,21 @@ def release(repository_name, dry_run, github_release_override=None, pypi_release
             if None, respect the configuration in pyproject.toml.
     """
     from . import github, pypi
-    pyproject = load_pyproject()
-    bork_config = pyproject.get('tool', {}).get('bork', {})
-    release_config = bork_config.get('release', {})
-    github_token = os.environ.get('BORK_GITHUB_TOKEN', None)
+    config = Config.from_project(Path.cwd())
+    credentials = Credentials.from_env()
+
     try:
         version = builder.version_from_bdist_file()
     except builder.NeedsBuildError:
         raise RuntimeError("No wheel files found. Please run 'bork build' first.")
 
-    project_name = pyproject.get('project', {}).get('name', None)
-
-    strip_zipapp_version = release_config.get('strip_zipapp_version', False)
-    globs = release_config.get('github_release_globs', ['./dist/*.pyz'])
-
-    release_to_github = release_config.get('github', False)
-    release_to_pypi = release_config.get('pypi', True)
-
-    if github_release_override is not None:
-        release_to_github = github_release_override
-
-    if pypi_release_override is not None:
-        release_to_pypi = pypi_release_override
-
+    release_to_github = github_release_override if github_release_override is not None else config.bork.release.github
+    release_to_pypi = pypi_release_override if pypi_release_override is not None else config.bork.release.pypi
     if not release_to_github and not release_to_pypi:
         raise RuntimeError('Configured to release to neither PyPi nor GitHub?')
 
     if release_to_github:
-        github_repository = release_config.get('github_repository', None)
-
-        if github_token is None:
+        if credentials.github is None:
             logger().error('No GitHub token specified. Use the BORK_GITHUB_TOKEN '
                 'environment variable to set it.')
 
@@ -159,11 +144,18 @@ def release(repository_name, dry_run, github_release_override=None, pypi_release
             else:
                 sys.exit(1)
 
-        config = github.GithubConfig(github_token, github_repository, project_name)
+        github_config = github.GithubConfig(
+            credentials.github,
+            config.bork.release.github_repository,
+            config.project_name
+        )
         github_release = github.GithubRelease(
-            config, tag=f'v{version}', commitish=None, body=None,
-            globs=globs,
-            dry_run=dry_run, strip_zipapp_version=strip_zipapp_version)
+            github_config,
+            tag = f'v{version}', commitish = None, body = None,
+            globs = config.bork.release.github_release_globs,
+            dry_run = dry_run,
+            strip_zipapp_version = config.bork.release.strip_zipapp_version,
+        )
         github_release.prepare()
 
     if release_to_pypi:
@@ -176,22 +168,17 @@ def release(repository_name, dry_run, github_release_override=None, pypi_release
 
 def run(alias):
     """Run the alias specified by `alias`, as defined in pyproject.toml."""
-    pyproject = load_pyproject()
-
-    try:
-        commands = pyproject['tool']['bork']['aliases'][alias]
-    except KeyError as error:
-        raise RuntimeError(f"No such alias: '{alias}'") from error
+    match aliases().get(alias):
+        case None:
+            raise RuntimeError(f"No such alias: '{alias}'")
+        case [*cmds]:
+            commands = cmds
+        case cmd if isinstance(cmd, str):
+            commands = (cmd, )
+        case x:
+            raise TypeError(f"commands must be (a sequence of) str, was {type(x)}")
 
     logger().info("Running '%s'", commands)
-
-    if isinstance(commands, str):
-        commands = [commands]
-    elif isinstance(commands, list):
-        pass
-    else:
-        raise TypeError(f"commands must be str or list, was {type(commands)}")
-
     try:
         for command in commands:
             print(command)

--- a/bork/builder.py
+++ b/bork/builder.py
@@ -34,7 +34,7 @@ with bork.builder.prepare(src_dir, artefacts_dir) as b:
 .. _wheel: https://packaging.python.org/en/latest/glossary/#term-Wheel
 """
 
-from .filesystem import load_pyproject
+from .config import Config
 from .log import logger
 
 import build
@@ -125,8 +125,7 @@ def prepare(src: Path, dst: Path) -> Iterator[Builder]:
             log.info("Building zipapp")
 
             log.debug("Loading configuration")
-            config = load_pyproject().get("tool", {}).get("bork", {})
-            zipapp_cfg = config.get("zipapp")
+            config = Config.from_project(self.src)
 
             log.debug("Loading metadata")
             meta = self.metadata()
@@ -147,8 +146,8 @@ def prepare(src: Path, dst: Path) -> Iterator[Builder]:
                 zipapp.create_archive(
                     source = tmp,
                     target = dst,
-                    interpreter = config.get('python_interpreter', DEFAULT_PYTHON_INTERPRETER),
-                    main = main or zipapp_cfg['main'],  # TODO: give a more user-friendly error if neither is set
+                    interpreter = config.bork.python_interpreter,
+                    main = main or config.bork.zipapp.main,  # TODO error if main is None and there's no __main__.py
                     compressed = True,
                 )
 

--- a/bork/cli.py
+++ b/bork/cli.py
@@ -14,14 +14,12 @@ Options that exist for all commands include:
 
 """
 
-import argparse
-import inspect
-import logging
-import sys
+from pathlib import Path
+import argparse, inspect, logging, sys
 
 from . import __version__
 from . import api
-from .filesystem import load_pyproject
+from .config import Config
 from .log import logger
 
 
@@ -46,15 +44,10 @@ def build(args):
 
     Build the project.
     """
-
-    pyproject = load_pyproject()
-    config = pyproject.get('tool', {}).get('bork', {})
-    zipapp_cfg = config.get('zipapp', {})
-    zipapp_enabled = zipapp_cfg.get('enabled', False)
-
     api.build()
 
-    if args.zipapp or zipapp_enabled:
+    config = Config.from_project(Path.cwd())
+    if args.zipapp or config.bork.zipapp.enabled:
         api.build_zipapp(args.zipapp_main)
 
 

--- a/bork/config.py
+++ b/bork/config.py
@@ -1,9 +1,9 @@
 from collections.abc import Mapping, Set, Sequence
 from functools import partial, reduce
 from pathlib import Path
-from typing import Optional # after Py3.10, replace string annotations with Self
+from typing import Annotated, Optional # after Py3.10, replace string annotations with Self
 
-from pydantic import dataclasses, TypeAdapter
+from pydantic import dataclasses, BeforeValidator, TypeAdapter
 
 try:
     import tomllib
@@ -33,10 +33,15 @@ class ZipappConfig:
     main: Optional[str] = None   # args.zipapp_main
     # TODO(nicoo): specify entrypoint format w/ regex annotation
 
+
+Commands = Annotated[
+    Sequence[str],
+    BeforeValidator(lambda x, _: (x, ) if isinstance(x, str) else x),
+]
+
 @dataclass
 class ToolConfig:
-    # TODO: normalize values to Sequence[str]
-    aliases: Mapping[str, Sequence[str] | str] = dataclasses.Field(default_factory = dict)
+    aliases: Mapping[str, Commands] = dataclasses.Field(default_factory = dict)
     release: ReleaseConfig = ReleaseConfig()
 
     python_interpreter: str = "/usr/bin/env python3"  # TODO: move to ZipappConfig

--- a/bork/config.py
+++ b/bork/config.py
@@ -1,0 +1,74 @@
+from collections.abc import Mapping, Set, Sequence
+from functools import partial, reduce
+from pathlib import Path
+from typing import Optional # after Py3.10, replace string annotations with Self
+
+from pydantic import dataclasses, TypeAdapter
+
+try:
+    import tomllib
+except ImportError:
+    # Py3.10 compatibility shim
+    import toml as tomllib  # type: ignore
+
+
+# TODO(nicoo): tie model definitions into CLI parsing
+
+# Ensure we don't accidentally make non-frozen or non-kw-only dataclasses
+dataclass = partial(dataclasses.dataclass, frozen = True, kw_only = True)
+
+@dataclass
+class ReleaseConfig:
+    # Related CLI flags: dry_run, pypi_repository
+    github: bool = False
+    github_release_globs: Set[str] = frozenset(("./dist/*.pyz", ))
+    github_repository: Optional[str] = None  # TODO(nicoo) refine type
+
+    pypi: bool = True
+    strip_zipapp_version: bool = False
+
+@dataclass
+class ZipappConfig:
+    enabled: bool = False        # args.zipapp
+    main: Optional[str] = None   # args.zipapp_main
+    # TODO(nicoo): specify entrypoint format w/ regex annotation
+
+@dataclass
+class ToolConfig:
+    # TODO: normalize values to Sequence[str]
+    aliases: Mapping[str, Sequence[str] | str] = dataclasses.Field(default_factory = dict)
+    release: ReleaseConfig = ReleaseConfig()
+
+    python_interpreter: str = "/usr/bin/env python3"  # TODO: move to ZipappConfig
+    zipapp: ZipappConfig = ZipappConfig()
+
+ToolConfigAdapter = TypeAdapter(ToolConfig)
+
+
+@dataclass
+class Config:
+    bork: ToolConfig
+    project_name: Optional[str] = None
+
+    @classmethod
+    def from_project(cls, root: Path) -> 'Config':
+        try:
+            # Inefficient but necessary for compatibility with toml shim
+            # To be improved once Py3.10 support is removed
+            pyproject = tomllib.loads((root / "pyproject.toml").read_text())
+        except FileNotFoundError:
+            if any((root / fn).exists() for fn in ("setup.py", "setup.cfg")):
+                # Legacy setuptools project without Bork-specific config
+                pyproject = {}
+            else:
+                raise
+
+        def get(*ks):
+            return reduce(lambda d, k: d.get(k, {}), ks, pyproject)
+
+        # TODO(nicoo) figure out why mypy doesn't accept this
+        #  according to the documentation it should
+        return Config( # type: ignore
+            bork = ToolConfigAdapter.validate_python(get("tool", "bork")),
+            project_name = get("project", "name") or None,  # get may return {}
+        )

--- a/bork/creds.py
+++ b/bork/creds.py
@@ -1,0 +1,43 @@
+from os import getenv
+from typing import Optional
+
+from pydantic.dataclasses import dataclass
+
+@dataclass(frozen = True, kw_only = True)
+class Credentials:
+    github: Optional[str] = None
+    pypi:   Optional['Credentials.PyPI'] = None
+
+    @classmethod
+    def from_env(cls) -> 'Credentials':
+        # TODO: support specifying another env than os.environ?
+        return cls(
+            github = getenv("BORK_GITHUB_TOKEN"),
+            pypi   = cls.PyPI.from_env(),
+        )
+
+    @dataclass(frozen = True)
+    class PyPI:
+        username: str
+        password: str
+
+        @classmethod
+        def from_env(cls) -> Optional['Credentials.PyPI']:
+            match getenv("BORK_PYPI_USERNAME"), getenv("BORK_PYPI_PASSWORD"), getenv("BORK_GITHUB_TOKEN"):
+                case username, password, None if username and password:
+                    return cls(username, password)
+                case None, None, token if token:
+                    return cls("__token__", token)
+                case None, None, None:
+                    return None
+
+                # Error cases
+                case _, password, token if password and token:
+                    raise RuntimeError("Cannot specify both BORK_PYPI_{PASSWORD, TOKEN}")
+                case (x, None, _) | (None, x, _) if x:
+                    raise RuntimeError(
+                        "Either both or none of BORK_PYPI_{USERNAME, PASSWORD} must be specified"
+                    )
+
+            # mypy cannot check for completeness of pattern matching (yet?)
+            raise AssertionError("Accidentally-incomplete pattern matching")

--- a/bork/filesystem.py
+++ b/bork/filesystem.py
@@ -2,35 +2,6 @@ from pathlib import Path
 import shutil
 import re
 
-try:
-    import tomllib
-except ImportError:
-    import toml as tomllib  # type: ignore
-
-
-def load_pyproject():
-    """
-    Loads the pyproject.toml data.
-
-    Will synthesize data if a legacy setuptools project is detected.
-    """
-    try:
-        pyproject = Path.cwd() / 'pyproject.toml'
-        return tomllib.loads(pyproject.read_text())  # Mildly inefficient, but portable
-
-    except FileNotFoundError:
-        if Path('setup.py').exists() or Path('setup.cfg').exists():
-            # Legacy project, use setuptools' legacy backend
-            # (This backend is specified in PEP517)
-            return {
-                'build-system': {
-                    'build-backend': 'setuptools.build_meta:__legacy__',
-                    'requires': ['setuptools>=42'],
-                },
-            }
-        # Can't figure out what kind of project it is.
-        raise
-
 
 def find_files(globs):
     files = []
@@ -40,7 +11,6 @@ def find_files(globs):
         files += list(matches)
 
     return files
-
 
 def try_delete(path):
     if Path(path).is_dir():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,15 +67,10 @@ packages = ["bork"]
 [tool.setuptools.dynamic]
 version = {attr = "bork.__version__"}
 
-[tool.bork.zipapp]
-enabled = true
-main = "bork.cli:main"
-
 [tool.bork.release]
 pypi = true
 github = true
 github_repository = "duckinator/bork"
-strip_zipapp_version = true
 
 [tool.bork.aliases]
 lint = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,15 @@ docs = "sphinx-build -b html -d build/doctrees docs/source/ docs/build/"
 docs-clean = "rm -rf docs/build/"
 #sphinx-apidoc = "sphinx-apidoc -o ./docs/source ./bork"
 
+[tool.mypy]
+plugins = [
+    "pydantic.mypy"
+]
+
+[tool.pydantic-mypy]
+init_forbid_extra = true
+init_typed = true
+
 [tool.ruff.lint]
 ignore = [
     "E401",  # multiple imports per line

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "homf ~= 1.1", # `bork download` stubs out to it
     "packaging ~= 23.2", # The packaging library is used by bork.github_api.
     "pip", # used by bork.builder._prepare_zipapp
+    "pydantic ~= 2.8",  # model & validate the configuration
     "urllib3 ~= 2.2",
 
     # Compatibility shims for older Python versions

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ test_dir = Path(__file__).parent
     ) + tuple(pytest.param(url, marks=(pytest.mark.network, pytest.mark.slow)) for url in (
     "https://github.com/astronouth7303/ppb-mutant.git",
     "https://github.com/duckinator/emanate.git",
+    "https://github.com/duckinator/homf.git",
     "https://github.com/ppb/ppb-vector.git",
 )))
 def project_src(request, tmp_path_factory):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,5 @@
+from bork.config import Config
+
+def test_config_compat(project_src):
+    "Check the new config model can validate known-good projects"
+    assert Config.from_project(project_src)

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -1,6 +1,18 @@
-from helpers import bork_check
+from bork.config import Config
+from helpers import bork_check, python_check
 
 def test_repo(project):
     bork_check('clean')
     bork_check('build')
     bork_check('release', '--dry-run')
+
+    if not Config.from_project(project).bork.zipapp.enabled:
+        return
+
+    match tuple((project / "dist").glob("*.pyz")):
+        case []:
+            assert False, "No zipapp was produced"
+        case [zipapp]:
+            python_check(zipapp, "--version")
+        case _:
+            assert False, "Multiple zipapps were produced?  O_o"


### PR DESCRIPTION
Model the configuration with [Pydantic], and convert the rest of Bork to use that rather than `load_pyproject` and raw dicts.

This shouldn't change the actual configuration schema, merely document and validate it.


## Rationale

- Document the data model
- Centralize the definition of config entries' types and default values
  Previously, each use of a config entry had its own idea about that
- Reliably validate the configuration
- Provide an abstraction terser and more ergonomic than raw dicts
  +37 -60 lines, excluding the model's implementation and removal of `load_pyproject`


## Drawbacks

[Pydantic] is a new dependency, with `pydantic_core` weighing ~2 MiB.
I don't think it matters all that much: Bork is a development tool, and its latest release was already 5 MiB.


[Pydantic]: https://docs.pydantic.dev/latest/
