### PR TITLE
Re-enable normal CI configuration.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,11 +1,8 @@
 Lint_task:
-  persistent_worker: &linux
-    isolation:
-      container:
-        image: python:3.12-slim
-        cpu: 1
-        memory: 512Mi
-
+  container: &linux
+    image: python:3.12-slim
+    cpu: 1
+    memory: 512Mi
   install_script:
     - pip install -U --upgrade-strategy eager pip 'setuptools>61'
     - pip install .
@@ -16,16 +13,14 @@ Lint_task:
     - bork run lint
 
 Linux_task:
-  persistent_worker: &linuxes
-    isolation:
-      container:
-        cpu: 1
-        memory: 512Mi
-        matrix:
-          - image: python:3.10-slim
-          - image: python:3.11-slim
-          - image: python:3.12-slim
-          - image: python:3.13-rc-slim
+  container:
+    cpu: 1
+    memory: 512Mi
+    matrix:
+      - image: python:3.10-slim
+      - image: python:3.11-slim
+      - image: python:3.12-slim
+      - image: python:3.13-rc-slim
   install_script:
     - apt-get update
     - apt-get install -y git
@@ -47,7 +42,6 @@ Linux_task:
 
 macOS_task:
   alias: macOS tests
-  skip: true
   macos_instance:
     cpu: 1
     image: ghcr.io/cirruslabs/macos-runner:sonoma
@@ -78,7 +72,6 @@ macOS_task:
 
 FreeBSD_task:
   alias: FreeBSD tests
-  skip: true
   freebsd_instance:
     image_family: freebsd-14-0
   env:
@@ -103,7 +96,6 @@ FreeBSD_task:
       type: text/xml
 
 Windows_task:
-  skip: true
   windows_container:
     image: cirrusci/windowsservercore:2019
   env:
@@ -144,7 +136,7 @@ success_task:
 # If bork/version.py is modified on the main branch, make a release.
 Release_task:
   stateful: true  # we don't want the task interrupted mid-release
-  persistent_worker: *linux
+  container: *linux
   only_if: "changesInclude('bork/version.py') && $BRANCH == 'main' && $CIRRUS_CRON == ''"
   depends_on: [CI success]
   env:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,7 +75,7 @@ FreeBSD_task:
   freebsd_instance:
     image_family: freebsd-14-2
   install_script:
-    - pkg install -y python310 git
+    - pkg install -y python310 git rust
     - python3.10 -m ensurepip
   pip_install_script:
     - python3.10 -m pip install -U --upgrade-strategy eager pip 'setuptools>61'

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,9 +116,7 @@ Windows_task:
 
 success_task:
   name: CI success
-  persistent_worker:
-    isolation:
-      container: {image: "busybox"}
+  container: *linux
   depends_on:
     - FreeBSD tests
     - Linux quick

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -75,13 +75,13 @@ FreeBSD_task:
   freebsd_instance:
     image_family: freebsd-14-0
   install_script:
-    - pkg install -y python git
-    - python -m ensurepip
+    - pkg install -y python310 git
+    - python3.10 -m ensurepip
   pip_install_script:
-    - python -m pip install -U --upgrade-strategy eager pip 'setuptools>61'
-    - python -m pip install .[test]
+    - python3.10 -m pip install -U --upgrade-strategy eager pip 'setuptools>61'
+    - python3.10 -m pip install .[test]
   script:
-    - python --version
+    - python3.10 --version
     - bork run test
   always:
     upload_results_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -74,20 +74,14 @@ FreeBSD_task:
   alias: FreeBSD tests
   freebsd_instance:
     image_family: freebsd-14-0
-  env:
-    matrix:
-      - PYTHON: 3.10
-      - PYTHON: 3.11
-      # TODO: PYTHON: 3.12
   install_script:
-    - PY=`echo $PYTHON | tr -d '.'`
-    - pkg install -y python${PY} git
-    - python${PYTHON} -m ensurepip
+    - pkg install -y python git
+    - python -m ensurepip
   pip_install_script:
-    - python${PYTHON} -m pip install -U --upgrade-strategy eager pip 'setuptools>61'
-    - python${PYTHON} -m pip install .[test]
+    - python -m pip install -U --upgrade-strategy eager pip 'setuptools>61'
+    - python -m pip install .[test]
   script:
-    - python${PYTHON} --version
+    - python --version
     - bork run test
   always:
     upload_results_artifacts:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -73,7 +73,7 @@ macOS_task:
 FreeBSD_task:
   alias: FreeBSD tests
   freebsd_instance:
-    image_family: freebsd-14-0
+    image_family: freebsd-14-2
   install_script:
     - pkg install -y python310 git
     - python3.10 -m ensurepip


### PR DESCRIPTION
Free CI credits were reset in September, so we can use those again instead of self-hosted workers.